### PR TITLE
🎨 Palette: Add accessibility labels to Hierarchy Table icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-20 - [Add accessibility labels to Hierarchy Table icon buttons]
+**Learning:** Observed a common pattern of missing ARIA labels on nested hierarchy UI elements, specifically icon-only buttons for dragging, expanding/collapsing, and deleting items.
+**Action:** Plan to establish a lint rule or common component wrapper for these interactive elements in the future to enforce consistent accessibility.

--- a/src/frontend/src/components/project-dashboard/hierarchy/HierarchyTable.tsx
+++ b/src/frontend/src/components/project-dashboard/hierarchy/HierarchyTable.tsx
@@ -114,6 +114,8 @@ const DraggableRow = ({ row }: any) => {
                 ref={setActivatorNodeRef}
                 {...listeners}
                 {...attributes}
+                aria-label="Drag item"
+                title="Drag item"
                 className="mr-2 cursor-grab text-muted-foreground hover:text-foreground active:cursor-grabbing"
               >
                 <GripVertical size={16} />
@@ -144,7 +146,12 @@ export function HierarchyTable() {
           return (
             <div style={{ paddingLeft: `${row.depth * 24}px` }} className="flex items-center gap-2 group">
               {row.getCanExpand() ? (
-                <button onClick={row.getToggleExpandedHandler()} className="cursor-pointer text-muted-foreground hover:text-foreground">
+                <button
+                  onClick={row.getToggleExpandedHandler()}
+                  aria-label={row.getIsExpanded() ? "Collapse item" : "Expand item"}
+                  title={row.getIsExpanded() ? "Collapse item" : "Expand item"}
+                  className="cursor-pointer text-muted-foreground hover:text-foreground"
+                >
                   {row.getIsExpanded() ? <ChevronDown size={16}/> : <ChevronRight size={16}/>}
                 </button>
               ) : <span className="w-4" />}
@@ -172,6 +179,8 @@ export function HierarchyTable() {
                   )}
                   {type !== 'project' && (
                       <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive hover:bg-destructive/10" 
+                        aria-label="Delete item"
+                        title="Delete item"
                         onClick={() => deleteItem(type, row.original.id)}>
                         <Trash2 size={12}/>
                       </Button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to the icon-only interactive elements within the `HierarchyTable.tsx` component. This includes the drag handle (`GripVertical`), the expand/collapse toggle (`ChevronDown`/`ChevronRight`), and the delete button (`Trash2`).

### 🎯 Why
Icon-only buttons are entirely inaccessible to screen readers without proper labeling. Additionally, sighted users benefit from hover tooltips (`title`) to clarify the function of an icon before clicking it. This micro-enhancement ensures consistent usability and accessibility for the task hierarchy.

### 📸 Before/After
**Before:**
Interactive icons like drag handles and delete buttons had no accessible names or tooltips.

**After:**
All interactive icons in the table rows have clear, descriptive `aria-label`s and `title` attributes (e.g., "Drag item", "Expand item", "Delete item").

### ♿ Accessibility
- Added descriptive text for screen readers using `aria-label`.
- Improved clarity for sighted users through `title` tooltips.
- Enhances keyboard navigation predictability.

---
*PR created automatically by Jules for task [3090476273527241586](https://jules.google.com/task/3090476273527241586) started by @jmbish04*