### PR TITLE
🎨 Palette: Add accessibility attributes to inline action buttons in ConfigTable

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - Accessible Inline Data Table Actions
+**Learning:** Icon-only buttons used for inline row actions in data tables (like edit, save, cancel) are completely invisible to screen readers without ARIA labels, and confusing to sighted users without tooltips. This is especially problematic in dense tables where context isn't obvious.
+**Action:** Always ensure any icon-only button, regardless of its placement inside complex components like tables, includes both an `aria-label` and `title` attribute explaining its function.

--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save configuration" title="Save configuration">
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving} aria-label="Cancel editing" title="Cancel editing">
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)} aria-label="Edit configuration" title="Edit configuration">
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to the icon-only "Edit", "Save", and "Cancel" buttons within the inline data rows of `ConfigTable.tsx`.

### 🎯 Why
Icon-only buttons used for inline row actions in data tables are completely invisible to screen readers without ARIA labels, making the table unusable for some users. Furthermore, without tooltips (via the `title` attribute), they can be confusing to sighted users, especially in dense tables where context isn't immediately obvious. 

### 📸 Before/After
**Before:** The buttons were just `Check`, `X`, and `Pencil` icons with no descriptive text or tooltips.
**After:** The buttons now have tooltips that appear on hover (e.g., "Save configuration") and announce their purpose to screen readers.

### ♿ Accessibility
- Ensured screen reader compatibility by explicitly labeling the action buttons (`aria-label`).
- Enhanced general usability by providing visual hover context (`title`).
- Documented this critical learning in `.Jules/palette.md` to establish a convention for future icon-only inline actions.

---
*PR created automatically by Jules for task [8493749607364068557](https://jules.google.com/task/8493749607364068557) started by @jmbish04*