### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to ConfigTable icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-03-24 - Accessibility for Icon-Only Buttons
+**Learning:** Found that multiple components (like ConfigTable) use icon-only buttons (`<Button size="icon">`) without providing `aria-label` or `title` attributes, making them inaccessible to screen readers and difficult to identify for sighted users who rely on tooltips.
+**Action:** When adding or reviewing icon-only buttons, always ensure they include an `aria-label` attribute for screen reader accessibility and a `title` attribute for hover tooltips.

--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save" title="Save">
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving} aria-label="Cancel" title="Cancel">
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)} aria-label="Edit" title="Edit">
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to the "Edit", "Save", and "Cancel" icon-only buttons within the `ConfigTable` component (`src/frontend/src/components/config/ConfigTable.tsx`). Also logged this accessibility finding in Palette's journal.

### 🎯 Why
Icon-only buttons without accessible labels cannot be interpreted by screen readers, creating a barrier for visually impaired users. Sighted users also benefit from hover tooltips (`title`) to clarify the exact action the icon represents, especially in data tables where actions like a checkmark or 'X' could mean multiple things.

### 📸 Before/After
*   **Before:** `<Button size="icon" variant="ghost" onClick={handleCancel}> <X className="h-4 w-4 text-red-500" /> </Button>`
*   **After:** `<Button size="icon" variant="ghost" onClick={handleCancel} aria-label="Cancel" title="Cancel"> <X className="h-4 w-4 text-red-500" /> </Button>`

### ♿ Accessibility
*   Screen readers will now read "Edit", "Save", and "Cancel" when focusing these buttons instead of ignoring them or reading "button".
*   Hover tooltips explicitly clarify intent for all users.

---
*PR created automatically by Jules for task [2231566052430477787](https://jules.google.com/task/2231566052430477787) started by @jmbish04*