### PR TITLE
🎨 Palette: Add ARIA labels and titles to icon-only buttons in Tracker components

### DIFF
--- a/src/frontend/src/components/project-dashboard/beta/TrackerBoardView.tsx
+++ b/src/frontend/src/components/project-dashboard/beta/TrackerBoardView.tsx
@@ -232,6 +232,8 @@ function TaskCard({
         <button
           {...dragListeners}
           className="mt-0.5 cursor-grab active:cursor-grabbing shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+          aria-label={`Drag task: ${task.title}`}
+          title={`Drag task: ${task.title}`}
         >
           <GripVertical className="w-3.5 h-3.5 text-muted-foreground" />
         </button>

--- a/src/frontend/src/components/project-dashboard/beta/TrackerLayout.tsx
+++ b/src/frontend/src/components/project-dashboard/beta/TrackerLayout.tsx
@@ -232,6 +232,8 @@ export function TrackerLayout({ tasks, isLoading, onTaskUpdate, onTaskCreate, on
               <button
                 onClick={() => setSearchQuery('')}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+                title="Clear search"
               >
                 <X className="w-3.5 h-3.5" />
               </button>

--- a/src/frontend/src/components/project-dashboard/beta/TrackerListView.tsx
+++ b/src/frontend/src/components/project-dashboard/beta/TrackerListView.tsx
@@ -143,7 +143,12 @@ export function TrackerListView({ tasks, isLoading, onTaskUpdate, onTaskDelete }
       {/* Header Row */}
       <div className="sticky top-0 z-10 bg-background border-b">
         <div className="flex items-center gap-3 px-4 py-2 text-xs text-muted-foreground">
-          <button onClick={toggleSelectAll} className="shrink-0">
+          <button
+            onClick={toggleSelectAll}
+            className="shrink-0"
+            aria-label="Select all tasks"
+            title="Select all tasks"
+          >
             {selectedIds.size === tasks.length && tasks.length > 0 ? (
               <CheckSquare className="w-4 h-4 text-primary" />
             ) : (
@@ -196,7 +201,12 @@ export function TrackerListView({ tasks, isLoading, onTaskUpdate, onTaskDelete }
                         selectedIds.has(task.id) && 'bg-accent/10'
                       )}
                     >
-                      <button onClick={() => toggleSelect(task.id)} className="shrink-0">
+                      <button
+                        onClick={() => toggleSelect(task.id)}
+                        className="shrink-0"
+                        aria-label={`Select task: ${task.title}`}
+                        title={`Select task: ${task.title}`}
+                      >
                         {selectedIds.has(task.id) ? (
                           <CheckSquare className="w-4 h-4 text-primary" />
                         ) : (
@@ -255,6 +265,8 @@ export function TrackerListView({ tasks, isLoading, onTaskUpdate, onTaskDelete }
                             <button
                               onClick={() => setEditingTag(task.id)}
                               className="opacity-0 group-hover:opacity-100 transition-opacity"
+                              aria-label="Add tag"
+                              title="Add tag"
                             >
                               <Tag className="w-3 h-3 text-muted-foreground hover:text-foreground" />
                             </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to several icon-only buttons across the `TrackerListView`, `TrackerLayout`, and `TrackerBoardView` components.

### 🎯 Why
Icon-only buttons without accessible names are invisible to screen readers, making the application inaccessible to visually impaired users. Adding `title` attributes also provides helpful hover tooltips for sighted users.

### 📸 Before/After
*   **Before:** Buttons like the clear search 'X' or the drag handle grip had no text context.
*   **After:** They now have descriptive `aria-label`s (e.g., "Clear search", "Select task: [task title]", "Drag task: [task title]") and matching `title` tooltips.

### ♿ Accessibility
This micro-improvement explicitly enhances keyboard and screen-reader accessibility for beta tracking tools without modifying any core layout or logic.

---
*PR created automatically by Jules for task [10130852803042256721](https://jules.google.com/task/10130852803042256721) started by @jmbish04*