### PR TITLE
🎨 Palette: Add accessibility labels to workshop header buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Icon-Only Navigation Buttons Missing Context
+**Learning:** Found several top-level navigation action buttons (like documentation, notifications, user profile) that relied solely on generic icons (`FileText`, `Bell`, empty div for avatar) without any accessible labels or tooltips. This is a common pattern in the app's components, causing screen readers to read nothing useful and sighted users to have to guess the action, especially for less standard icons.
+**Action:** Ensure that all icon-only buttons globally implement both `aria-label` for screen reader accessibility and `title` attributes for sighted user tooltips, particularly in global navigation headers.

--- a/src/frontend/src/components/workshop/WorkshopTakeover.tsx
+++ b/src/frontend/src/components/workshop/WorkshopTakeover.tsx
@@ -41,14 +41,26 @@ export function WorkshopTakeover() {
                                 Create Agent
                             </button>
                             <div className="flex items-center gap-2 border-l border-zinc-200 dark:border-zinc-800 pl-4 ml-2">
-                                <button className="flex items-center justify-center rounded-full w-9 h-9 text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 transition-colors">
+                                <button
+                                    className="flex items-center justify-center rounded-full w-9 h-9 text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 transition-colors"
+                                    aria-label="View documentation"
+                                    title="View documentation"
+                                >
                                     <FileText className="w-5 h-5" />
                                 </button>
-                                <button className="relative flex items-center justify-center rounded-full w-9 h-9 text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 transition-colors">
+                                <button
+                                    className="relative flex items-center justify-center rounded-full w-9 h-9 text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 transition-colors"
+                                    aria-label="View notifications"
+                                    title="View notifications"
+                                >
                                     <Bell className="w-5 h-5" />
                                     <span className="absolute top-1 right-1 block w-2 h-2 rounded-full bg-amber-500 ring-2 ring-zinc-900"></span>
                                 </button>
-                                <button className="ml-2 flex items-center justify-center rounded-full overflow-hidden border-2 border-transparent hover:border-blue-500 transition-colors">
+                                <button
+                                    className="ml-2 flex items-center justify-center rounded-full overflow-hidden border-2 border-transparent hover:border-blue-500 transition-colors"
+                                    aria-label="User profile menu"
+                                    title="User profile menu"
+                                >
                                     <div className="w-8 h-8 rounded-full bg-zinc-800"></div>
                                 </button>
                             </div>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to the three icon-only buttons (documentation, notifications, user profile) in the top right navigation of the `WorkshopTakeover` component.

### 🎯 Why
Icon-only buttons without accessible names are invisible to screen readers and force sighted users to guess their function. Adding these attributes ensures the buttons are properly announced by assistive technologies and provide helpful hover tooltips for all users.

### 📸 Before/After
*   **Before:** `<button><FileText /></button>`
*   **After:** `<button aria-label="View documentation" title="View documentation"><FileText /></button>`

### ♿ Accessibility
*   Improves screen reader context.
*   Provides hover tooltips for sighted users.
*   Documented learning regarding global navigation icon-only buttons in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [13362943957893798754](https://jules.google.com/task/13362943957893798754) started by @jmbish04*