### PR TITLE
🎨 Palette: Add accessibility attributes to icon-only buttons

### DIFF
--- a/src/frontend/src/components/LiveOpsConsole.tsx
+++ b/src/frontend/src/components/LiveOpsConsole.tsx
@@ -186,7 +186,7 @@ export function LiveOpsConsole({ operationId }: LiveOpsConsoleProps) {
                             placeholder="Ask Supervisor..."
                             className="h-8 text-xs bg-zinc-950 border-zinc-700"
                         />
-                        <Button type="submit" size="icon" className="h-8 w-8">
+                        <Button type="submit" size="icon" className="h-8 w-8" aria-label="Send message" title="Send message">
                             <Send className="w-3 h-3" />
                         </Button>
                     </form>

--- a/src/frontend/src/components/PRCommandCenter.tsx
+++ b/src/frontend/src/components/PRCommandCenter.tsx
@@ -246,7 +246,7 @@ export function PRCommandCenter({ repoOwner, repoName, initialPrs }: PRCommandCe
         <div className="h-[calc(100vh-100px)] flex flex-col gap-4">
             <div className="flex flex-col xl:flex-row items-start xl:items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
-                    <Button variant="ghost" size="icon" onClick={() => setSelectedPrNumber(null)}>
+                    <Button variant="ghost" size="icon" onClick={() => setSelectedPrNumber(null)} aria-label="Back" title="Back">
                         <ArrowLeft className="w-4 h-4" />
                     </Button>
                     <div>

--- a/src/frontend/src/components/PlanningCenter.tsx
+++ b/src/frontend/src/components/PlanningCenter.tsx
@@ -225,7 +225,7 @@ function PlanningRoom({ requestId, onBack }: { requestId: string; onBack: () => 
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-[#1f2937] bg-black/20 backdrop-blur-md">
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" onClick={onBack} className="md:hidden">
+          <Button variant="ghost" size="icon" onClick={onBack} className="md:hidden" aria-label="Back to requests" title="Back to requests">
             <ChevronRight className="w-5 h-5 rotate-180" />
           </Button>
           <div className="flex flex-col">

--- a/src/frontend/src/components/chat/chat-interface.tsx
+++ b/src/frontend/src/components/chat/chat-interface.tsx
@@ -163,7 +163,7 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ apiKey, agentId, r
             <div className="w-80 border-r bg-muted/10 flex flex-col">
                 <div className="p-4 border-b flex items-center justify-between bg-background/50 backdrop-blur">
                     <span className="font-semibold text-sm">Discussions</span>
-                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleCreateThread}>
+                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleCreateThread} aria-label="Create new thread" title="Create new thread">
                         <Plus className="h-4 w-4" />
                     </Button>
                 </div>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to icon-only buttons across multiple frontend components (`LiveOpsConsole`, `PRCommandCenter`, `PlanningCenter`, and `ChatInterface`).

### 🎯 Why
Icon-only buttons without accessible names cannot be read or understood by screen readers, creating a barrier for visually impaired users. Adding `aria-label` makes them accessible, and `title` provides a helpful tooltip for mouse users, improving the overall UX.

### 📸 Before/After
*   **Before:** `<Button size="icon"><Icon /></Button>`
*   **After:** `<Button size="icon" aria-label="Action description" title="Action description"><Icon /></Button>`

### ♿ Accessibility
*   Improves screen reader accessibility by providing descriptive labels for previously unlabeled icon-only buttons.
*   Enhances usability for sighted users by providing hover tooltips indicating the button's action.

---
*PR created automatically by Jules for task [11323360698628562714](https://jules.google.com/task/11323360698628562714) started by @jmbish04*