### PR TITLE
🎨 Palette: Config Table Icon Button Accessibility & Loading States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Icon-Only Button Accessibility in Config Table
+**Learning:** Config tables often rely heavily on icon-only buttons (like Edit/Save/Cancel) to save horizontal space, which frequently lack proper ARIA labels and tooltips, causing severe accessibility and usability issues for screen reader users and those navigating complex settings.
+**Action:** Always ensure icon-only buttons in dense data tables or lists include `aria-label` and `title` attributes. Additionally, include visual loading states directly within the button for async actions (like Save) to prevent user confusion.

--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Pencil, Check, X, Eye, EyeOff } from "lucide-react";
+import { Pencil, Check, X, Eye, EyeOff, Loader2 } from "lucide-react";
 
 export type ConfigFieldType = "string" | "number" | "boolean" | "secret";
 
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
-                        <Check className="h-4 w-4 text-green-500" />
+                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save configuration" title="Save configuration">
+                        {isSaving ? <Loader2 className="h-4 w-4 animate-spin text-green-500" /> : <Check className="h-4 w-4 text-green-500" />}
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving} aria-label="Cancel editing" title="Cancel editing">
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)} aria-label="Edit configuration" title="Edit configuration">
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` and `title` attributes to the icon-only buttons (Edit, Save, Cancel) in the `ConfigTable` component. Additionally, incorporated a visual loading spinner (`Loader2`) that appears within the Save button when `isSaving` is true.

### 🎯 Why
Icon-only buttons without `aria-label`s are opaque to screen readers, and without `title` tooltips, sighted users may have to guess their function. Adding these attributes vastly improves both accessibility and general usability. The loading spinner provides immediate feedback during asynchronous save operations, reassuring the user that their action was registered.

### 📸 Before/After
*Before:*
```tsx
<Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
  <Check className="h-4 w-4 text-green-500" />
</Button>
```

*After:*
```tsx
<Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save configuration" title="Save configuration">
  {isSaving ? <Loader2 className="h-4 w-4 animate-spin text-green-500" /> : <Check className="h-4 w-4 text-green-500" />}
</Button>
```

### ♿ Accessibility
*   **Screen Readers:** The Edit, Save, and Cancel buttons now announce their intended actions clearly rather than just announcing "button".
*   **Visual Impairments/Usability:** Tooltips appear on hover, clarifying the button's purpose without requiring prior knowledge. 
*   **Cognitive Load:** The loading state provides clear feedback that the system is processing the request.

---
*PR created automatically by Jules for task [9348345258500426326](https://jules.google.com/task/9348345258500426326) started by @jmbish04*