### PR TITLE
🎨 Palette: Add accessible label to Workflows Play button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Missing ARIA Labels on Icon Buttons
+**Learning:** Found a pattern of missing `aria-label` and `title` attributes on `<Button size="icon">` elements across the UI, particularly in modals and settings. Icon-only buttons without these attributes are completely opaque to screen readers and difficult for sighted users to decipher without hover tooltips.
+**Action:** When adding or reviewing `<Button size="icon">` usage, always ensure `aria-label` is present for screen readers and `title` is present to provide hover tooltips for sighted users.

--- a/src/frontend/src/components/modals/WorkflowsModal.tsx
+++ b/src/frontend/src/components/modals/WorkflowsModal.tsx
@@ -39,7 +39,13 @@ export function WorkflowsModal({ workflowCount = 8 }: { workflowCount?: number }
                                         </div>
                                         <div className="font-medium text-sm">{wf}</div>
                                     </div>
-                                    <Button size="icon" variant="ghost" className="h-8 w-8 hover:bg-zinc-800">
+                                    <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        className="h-8 w-8 hover:bg-zinc-800"
+                                        aria-label={`Run ${wf} workflow`}
+                                        title={`Run ${wf} workflow`}
+                                    >
                                         <Play className="w-4 h-4 text-zinc-400" />
                                     </Button>
                                 </CardContent>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to the icon-only "Play" button in the `WorkflowsModal` component.

### 🎯 Why
Icon-only buttons without accessible names are opaque to screen readers. Sighted users also benefit from hover tooltips (`title`) to confirm the button's intended action without guesswork. This improves the overall accessibility and discoverability of the workflows list.

### 📸 Before/After
**Before:** `<Button size="icon"><Play/></Button>` (Silent to screen readers, no hover text).
**After:** `<Button size="icon" aria-label="Run {wf} workflow" title="Run {wf} workflow"><Play/></Button>` (Clear description for all users).

### ♿ Accessibility
- Provides a clear accessible name (`aria-label`) for assistive technologies.
- Enhances usability for sighted users by providing a native hover tooltip (`title`).
- Fixes a common pattern of inaccessible icon buttons across the UI, noted in the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [3461954649909327219](https://jules.google.com/task/3461954649909327219) started by @jmbish04*