### PR TITLE
🎨 Palette: [UX] Add accessible labels to icon-only buttons in Tracker Layout

### DIFF
--- a/src/frontend/src/components/project-dashboard/beta/TrackerLayout.tsx
+++ b/src/frontend/src/components/project-dashboard/beta/TrackerLayout.tsx
@@ -232,6 +232,8 @@ export function TrackerLayout({ tasks, isLoading, onTaskUpdate, onTaskCreate, on
               <button
                 onClick={() => setSearchQuery('')}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+                title="Clear search"
               >
                 <X className="w-3.5 h-3.5" />
               </button>
@@ -302,7 +304,7 @@ export function TrackerLayout({ tasks, isLoading, onTaskUpdate, onTaskCreate, on
                     placeholder="Ask anything..."
                     className="h-8 text-sm"
                   />
-                  <Button size="sm" className="h-8 px-3" onClick={handleAiSend}>
+                  <Button size="sm" className="h-8 px-3" onClick={handleAiSend} aria-label="Send message" title="Send message">
                     <Send className="w-3.5 h-3.5" />
                   </Button>
                 </div>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to the "Clear search" and "Send message" icon-only buttons in the TrackerLayout component.

### 🎯 Why
Icon-only buttons are inaccessible to screen reader users and can be ambiguous to sighted users. Adding these attributes ensures the buttons are clearly described both audibly and visually (via tooltips).

### 📸 Before/After
*Before:*
`<button><X /></button>` and `<Button><Send /></Button>`

*After:*
`<button aria-label="Clear search" title="Clear search"><X /></button>`
`<Button aria-label="Send message" title="Send message"><Send /></Button>`

### ♿ Accessibility
Improved screen reader accessibility by providing descriptive labels for previously unlabelled interactive elements. Sighted users also benefit from native browser tooltips on hover.

---
*PR created automatically by Jules for task [7935521545994010042](https://jules.google.com/task/7935521545994010042) started by @jmbish04*