### PR TITLE
🎨 Palette: Improve ConfigTable action button accessibility

### DIFF
--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save changes" title="Save changes">
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving} aria-label="Cancel editing" title="Cancel editing">
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)} aria-label="Edit setting" title="Edit setting">
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to the icon-only "Save", "Cancel", and "Edit" buttons within the `ConfigTable` component's action column.

🎯 **Why:** To improve accessibility for screen readers, which previously had no context for what these icon buttons did, and to provide helpful hover tooltips for sighted users navigating the settings grid.

📸 **Before/After:** Sighted users now see tooltips ("Save changes", "Cancel editing", "Edit setting") when hovering over the action buttons in the config table.

♿ **Accessibility:** Screen readers will now announce "Save changes button", "Cancel editing button", and "Edit setting button" instead of just "button".

---
*PR created automatically by Jules for task [9012894904113063148](https://jules.google.com/task/9012894904113063148) started by @jmbish04*