### PR TITLE
🎨 Palette: Add tooltip to sidebar toggle button

### DIFF
--- a/src/frontend/src/layouts/RootLayout.tsx
+++ b/src/frontend/src/layouts/RootLayout.tsx
@@ -86,6 +86,7 @@ export default function RootLayout() {
                             className="shrink-0"
                             onClick={() => setIsSidebarOpen((v) => !v)}
                             aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+                            title={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
                         >
                             {isSidebarOpen ? (
                                 <PanelLeftClose className="h-5 w-5" />


### PR DESCRIPTION
## 💡 What
Added a `title` attribute to the sidebar toggle `<Button>` in `RootLayout.tsx`.

## 🎯 Why
This button is icon-only and while it has an `aria-label` for screen readers, sighted users relying on hover had no tooltip indicating its function. Adding the `title` attribute provides a native browser tooltip, improving usability and accessibility.

## 📸 Before/After
N/A - Native browser tooltip now appears on hover.

## ♿ Accessibility
Improves the experience for sighted users by providing a text alternative when hovering over the icon-only toggle button. Screen reader experience remains unaffected as `aria-label` was already present.

---
*PR created automatically by Jules for task [7019734759407600105](https://jules.google.com/task/7019734759407600105) started by @jmbish04*