### PR TITLE
🎨 Palette: Add aria-label and title to icon-only buttons in CloudflareDocsBetaPage

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-01 - Add context to icon-only buttons
+**Learning:** Found that icon-only buttons (like Send or Stop in chat interfaces) often lack both `aria-label` for screen readers and `title` for sighted users simultaneously. This breaks accessibility and degrades UX for users relying on mouse-hover tooltips for clarity.
+**Action:** Always ensure icon-only buttons get an explicit `aria-label` attribute and a matching `title` attribute for tooltip rendering.

--- a/src/frontend/src/components/tools/toolbox/CloudflareDocsBetaPage.tsx
+++ b/src/frontend/src/components/tools/toolbox/CloudflareDocsBetaPage.tsx
@@ -513,6 +513,7 @@ function BetaThreadSidebar({
                                         onClick={e => { e.stopPropagation(); setConfirmId(t.id); }}
                                         className="absolute top-2 right-2 p-1.5 rounded-lg opacity-0 group-hover:opacity-100 text-muted-foreground/40 hover:text-red-400 hover:bg-red-500/10 transition-all"
                                         aria-label="Delete thread"
+                                        title="Delete thread"
                                     >
                                         <Trash2 className="w-3 h-3" />
                                     </button>
@@ -937,6 +938,7 @@ function BetaChatPanel({
                                     }}
                                     className="p-2 rounded-xl text-red-400 hover:bg-red-500/10 shrink-0 transition-colors"
                                     title="Stop generating"
+                                    aria-label="Stop generating"
                                 >
                                     <Square className="w-4 h-4" />
                                 </button>
@@ -945,6 +947,8 @@ function BetaChatPanel({
                                     onClick={() => sendMessage()}
                                     disabled={!input.trim() || wsStatus !== "open"}
                                     className="p-2 rounded-xl bg-orange-500 hover:bg-orange-600 text-white disabled:opacity-30 disabled:cursor-not-allowed shrink-0 transition-colors shadow-md shadow-orange-500/20"
+                                    title="Send message"
+                                    aria-label="Send message"
                                 >
                                     <Send className="w-4 h-4" />
                                 </button>


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` and `title` attributes to the "Stop generating", "Send message", and "Delete thread" icon-only buttons in `CloudflareDocsBetaPage.tsx`. Also created an entry in `.Jules/palette.md` noting this standard.

### 🎯 Why
Icon-only buttons rely on these attributes to convey their purpose to screen reader users (via `aria-label`) and sighted users interacting via mouse hover tooltips (via `title`). Missing these creates an accessibility gap and a frustrating UX when the meaning of the icon is ambiguous. 

### 📸 Before/After
**Before:** Buttons like the Square icon or Send icon lacked explicit titles, meaning hovering over them provided no context.
**After:** Hovering over them yields standard tooltips like "Stop generating" or "Send message", and screen readers announce them properly.

### ♿ Accessibility
Improves WCAG compliance by explicitly naming interactive icon buttons using `aria-label`.

---
*PR created automatically by Jules for task [14051638729972305809](https://jules.google.com/task/14051638729972305809) started by @jmbish04*