### PR TITLE
🎨 Palette: Add ARIA labels to tracker buttons

### DIFF
--- a/src/frontend/src/components/project-dashboard/beta/TrackerListView.tsx
+++ b/src/frontend/src/components/project-dashboard/beta/TrackerListView.tsx
@@ -143,7 +143,7 @@ export function TrackerListView({ tasks, isLoading, onTaskUpdate, onTaskDelete }
       {/* Header Row */}
       <div className="sticky top-0 z-10 bg-background border-b">
         <div className="flex items-center gap-3 px-4 py-2 text-xs text-muted-foreground">
-          <button onClick={toggleSelectAll} className="shrink-0">
+          <button onClick={toggleSelectAll} className="shrink-0" aria-label="Select all tasks" title="Select all tasks">
             {selectedIds.size === tasks.length && tasks.length > 0 ? (
               <CheckSquare className="w-4 h-4 text-primary" />
             ) : (
@@ -196,7 +196,7 @@ export function TrackerListView({ tasks, isLoading, onTaskUpdate, onTaskDelete }
                         selectedIds.has(task.id) && 'bg-accent/10'
                       )}
                     >
-                      <button onClick={() => toggleSelect(task.id)} className="shrink-0">
+                      <button onClick={() => toggleSelect(task.id)} className="shrink-0" aria-label="Select task" title="Select task">
                         {selectedIds.has(task.id) ? (
                           <CheckSquare className="w-4 h-4 text-primary" />
                         ) : (
@@ -255,6 +255,8 @@ export function TrackerListView({ tasks, isLoading, onTaskUpdate, onTaskDelete }
                             <button
                               onClick={() => setEditingTag(task.id)}
                               className="opacity-0 group-hover:opacity-100 transition-opacity"
+                              aria-label="Add tag"
+                              title="Add tag"
                             >
                               <Tag className="w-3 h-3 text-muted-foreground hover:text-foreground" />
                             </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to three icon-only buttons in `TrackerListView.tsx`.

### 🎯 Why
Icon-only buttons without accessible names are inaccessible to screen reader users and lack tooltips for sighted users. This change improves accessibility and usability.

### ♿ Accessibility
- Added `aria-label="Select all tasks"` to the header checkbox button.
- Added `aria-label="Select task"` to the row checkbox buttons.
- Added `aria-label="Add tag"` to the row tag buttons.
- All three buttons now also have a corresponding `title` attribute for hover tooltips.

---
*PR created automatically by Jules for task [4868385740697286221](https://jules.google.com/task/4868385740697286221) started by @jmbish04*