### PR TITLE
🎨 Palette: Add accessibility labels and tooltips to config buttons

### DIFF
--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button aria-label="Save" title="Save" size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button aria-label="Cancel" title="Cancel" size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button aria-label="Edit" title="Edit" size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}

--- a/src/frontend/src/components/config/Header.tsx
+++ b/src/frontend/src/components/config/Header.tsx
@@ -29,7 +29,7 @@ export function ConfigHeader({
       </div>
       
       <div className="flex items-center gap-2">
-        <Button variant="ghost" size="icon" onClick={onRefresh} disabled={isRefreshing}>
+        <Button aria-label="Refresh" title="Refresh" variant="ghost" size="icon" onClick={onRefresh} disabled={isRefreshing}>
            <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
         </Button>
         <Button variant="ghost" size="sm" asChild>

--- a/src/frontend/src/components/config/StandardizationConfig.tsx
+++ b/src/frontend/src/components/config/StandardizationConfig.tsx
@@ -229,7 +229,7 @@ export function StandardizationConfig() {
                     <td className="px-4 py-3 font-mono text-xs">{config.targetRepoPattern}</td>
                     <td className="px-4 py-3 text-xs text-muted-foreground">{config.triggerEvents}</td>
                     <td className="px-4 py-3">
-                      <Button variant="ghost" size="icon" onClick={() => handleDeleteConfig(config.id)} className="h-8 w-8 text-destructive hover:bg-destructive/10">
+                      <Button aria-label="Delete config" title="Delete config" variant="ghost" size="icon" onClick={() => handleDeleteConfig(config.id)} className="h-8 w-8 text-destructive hover:bg-destructive/10">
                         <Trash2 className="w-4 h-4" />
                       </Button>
                     </td>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `title` attributes to five different icon-only buttons across the `ConfigTable`, `StandardizationConfig`, and `Header` components in the configuration settings view.

### 🎯 Why
Icon-only buttons without text content or screen-reader accessible labels are effectively invisible or announced as generic "buttons" to assistive technologies, making the interface confusing or impossible to navigate for some users. Adding `title` tooltips also aids sighted users in quickly understanding what these action icons (Check, X, Pencil, Trash, Refresh) perform before clicking them.

### 📸 Before/After
*(Visual change is purely the addition of hover tooltips on standard action buttons).*
**Before:** Hovering over the Save/Cancel/Edit/Delete/Refresh buttons provided no descriptive tooltip. Screen readers read them as generic unlabelled buttons.
**After:** Hovering over the buttons displays native browser tooltips ("Save", "Cancel", "Edit", "Delete config", "Refresh"). Screen readers properly announce the button's purpose.

### ♿ Accessibility
- Fixed WCAG 4.1.2 (Name, Role, Value) issues on five core action buttons by explicitly providing accessible names via `aria-label`.
- Enhanced cognitive accessibility by providing immediate textual context (`title`) on hover for symbolic icons.

---
*PR created automatically by Jules for task [1799908119225175793](https://jules.google.com/task/1799908119225175793) started by @jmbish04*