### PR TITLE
🎨 Palette: Add accessibility labels to icon-only buttons in ConfigTable

### DIFF
--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save configuration" title="Save configuration">
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving} aria-label="Cancel editing" title="Cancel editing">
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)} aria-label="Edit configuration" title="Edit configuration">
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
## 💡 What
Added `aria-label` and `title` attributes to the "Save", "Cancel", and "Edit" icon-only buttons in the `ConfigTable` component (`src/frontend/src/components/config/ConfigTable.tsx`).

## 🎯 Why
Icon-only buttons without accessible names are invisible to screen readers and difficult to understand for sighted users without tooltips. Adding these attributes ensures the buttons are clear and accessible to all users.

## 📸 Before/After
*   **Before:** `<Button size="icon" variant="ghost" onClick={handleCancel}>`
*   **After:** `<Button size="icon" variant="ghost" onClick={handleCancel} aria-label="Cancel editing" title="Cancel editing">`

## ♿ Accessibility
*   **Screen Readers:** Users navigating with assistive technologies will now hear "Save configuration", "Cancel editing", or "Edit configuration" instead of a generic or unlabelled button.
*   **Hover Tooltips:** Sighted users hovering over the icons will see a standard browser tooltip explaining the button's action.

---
*PR created automatically by Jules for task [3429667714405401377](https://jules.google.com/task/3429667714405401377) started by @jmbish04*