### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Todo view

### DIFF
--- a/src/frontend/src/views/control/global/Todo.tsx
+++ b/src/frontend/src/views/control/global/Todo.tsx
@@ -202,6 +202,7 @@ function PostItCard({
           onClick={() => onMarkDone(note.id)}
           style={{ position: "absolute", top: 6, left: 6, background: "transparent", border: "none", cursor: "pointer", opacity: 0.6, padding: 2, color: "#1a1a1a" }}
           title="Mark done"
+          aria-label="Mark done"
         >
           <CheckCircle2 size={13} />
         </button>
@@ -211,6 +212,7 @@ function PostItCard({
           onClick={() => onEdit(note.id)}
           style={{ position: "absolute", top: 6, right: 30, background: "transparent", border: "none", cursor: "pointer", opacity: 0.6, padding: 2, color: "#1a1a1a" }}
           title="Edit note"
+          aria-label="Edit note"
         >
           <Pencil size={13} />
         </button>
@@ -220,6 +222,7 @@ function PostItCard({
           onClick={() => onDelete(note.id)}
           style={{ position: "absolute", top: 6, right: 6, background: "transparent", border: "none", cursor: "pointer", opacity: 0.6, padding: 2, color: "#1a1a1a" }}
           title="Remove note"
+          aria-label="Remove note"
         >
           <X size={13} />
         </button>
@@ -273,6 +276,7 @@ function TornLabel({
           onClick={() => onEdit(label.id)}
           style={{ position: "absolute", top: -4, right: 20, background: "#333", border: "none", borderRadius: "50%", width: 18, height: 18, color: "#fff", cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.8, zIndex: 10 }}
           title="Edit label"
+          aria-label="Edit label"
         >
           <Pencil size={10} />
         </button>
@@ -280,6 +284,7 @@ function TornLabel({
           onClick={() => onDelete(label.id)}
           style={{ position: "absolute", top: -4, right: -4, background: "#333", border: "none", borderRadius: "50%", width: 18, height: 18, color: "#fff", cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.8, zIndex: 10 }}
           title="Remove label"
+          aria-label="Remove label"
         >
           <X size={10} />
         </button>
@@ -582,7 +587,7 @@ export default function TodoPage() {
               <Label style={{ marginBottom: 6, display: "block", fontSize: 12 }}>Color</Label>
               <div style={{ display: "flex", gap: 8 }}>
                 {NOTE_COLORS.map(c => (
-                  <button key={c} onClick={() => setNewColor(c)} style={{ width: 28, height: 28, borderRadius: 4, background: c, border: c === newColor ? "3px solid #fff" : "2px solid transparent", cursor: "pointer", boxShadow: c === newColor ? "0 0 0 1px #888" : "none" }} />
+                  <button key={c} onClick={() => setNewColor(c)} aria-label={`Select color ${c}`} style={{ width: 28, height: 28, borderRadius: 4, background: c, border: c === newColor ? "3px solid #fff" : "2px solid transparent", cursor: "pointer", boxShadow: c === newColor ? "0 0 0 1px #888" : "none" }} />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to multiple icon-only and visual-only `<button>` elements within the `Todo.tsx` component. This includes the buttons on individual Post-it notes (Mark done, Edit, Remove), group labels (Edit, Remove), and the color picker selection squares in the New/Edit Note dialog.

### 🎯 Why
Icon-only buttons present a significant accessibility barrier. Sighted users rely on visual cues (like a Trash icon) or hover `title` tooltips, but screen readers require an explicit textual name to convey the button's purpose to visually impaired users. Adding `aria-label` ensures these elements are correctly announced, satisfying our accessibility requirements for inclusive design.

### 📸 Before/After
**Before:**
```tsx
<button title="Remove note">
  <X size={13} />
</button>
```
*(Screen readers might announce this vaguely as "button" or read the raw SVG text.)*

**After:**
```tsx
<button title="Remove note" aria-label="Remove note">
  <X size={13} />
</button>
```
*(Screen readers will clearly announce "Remove note button".)*

### ♿ Accessibility
-   **WCAG 2.1 Success Criterion 4.1.2 Name, Role, Value:** Fully addresses this by providing accessible names (`aria-label`) for interactive components that previously lacked textual context.
-   **Screen Reader Support:** Drastically improves the experience for users navigating via screen readers (e.g., VoiceOver, NVDA, JAWS) across the Todo corkboard interface.

---
*PR created automatically by Jules for task [10532187321085838998](https://jules.google.com/task/10532187321085838998) started by @jmbish04*