### PR TITLE
🎨 Palette: Add aria-label to NumericKeypad Delete button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - Numeric Keypad Accessibility
+**Learning:** Found a custom numeric keypad component where the delete button only contained an icon (`<Delete className="h-6 w-6" />`) without any `aria-label` or `title`. This makes it completely opaque to screen readers and doesn't provide hover context for sighted users.
+**Action:** Always add `aria-label` and `title` to icon-only buttons, especially in custom input components like keypads where context isn't provided by standard form elements.

--- a/src/frontend/src/components/auth/numeric-keypad.tsx
+++ b/src/frontend/src/components/auth/numeric-keypad.tsx
@@ -91,6 +91,8 @@ export const NumericKeypad: React.FC<NumericKeypadProps> = ({ onComplete }) => {
                     </button>
                     <button
                         onClick={handleDelete}
+                        aria-label="Delete"
+                        title="Delete"
                         className="h-16 w-16 rounded-full bg-destructive/10 hover:bg-destructive/20 text-destructive flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                     >
                         <Delete className="h-6 w-6" />


### PR DESCRIPTION
## 💡 What
Added `aria-label="Delete"` and `title="Delete"` to the icon-only delete button in the `NumericKeypad` component. Additionally, logged a critical learning about icon-only buttons in `.Jules/palette.md`.

## 🎯 Why
Icon-only buttons without `aria-label`s are completely opaque to screen readers, making them inaccessible. Furthermore, without a `title`, sighted users do not receive a native browser tooltip on hover to clarify the button's action.

## 📸 Before/After
- Before: `<button><Delete className="h-6 w-6" /></button>`
- After: `<button aria-label="Delete" title="Delete"><Delete className="h-6 w-6" /></button>`

## ♿ Accessibility
- Improves screen reader accessibility by providing an explicit `aria-label`.
- Enhances usability for sighted users by providing a hover tooltip via the `title` attribute.

---
*PR created automatically by Jules for task [14880937279312800472](https://jules.google.com/task/14880937279312800472) started by @jmbish04*