### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and titles to ConfigTable icon buttons

### DIFF
--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save changes" title="Save changes">
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving} aria-label="Cancel editing" title="Cancel editing">
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)} aria-label="Edit configuration" title="Edit configuration">
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
## 💡 What
Added `aria-label` and `title` attributes to the Edit, Save, and Cancel icon-only buttons in `ConfigTable.tsx`.

## 🎯 Why
Icon-only buttons without accessible labels are invisible or confusing to screen readers. Adding `aria-label` fixes this accessibility issue, while adding `title` provides helpful hover tooltips for sighted users. This ensures the configuration settings are manageable by all users.

## 📸 Before/After
Before: The buttons only contained Lucide icons without semantic text.
After: The buttons contain clear text definitions via `aria-label` and `title` attributes.

## ♿ Accessibility
- Provides descriptive names for screen readers (`Edit configuration`, `Save changes`, `Cancel editing`)
- Follows WCAG guidelines for icon-only interactive elements
- Uses existing Radix UI button architecture without modifying global styles

---
*PR created automatically by Jules for task [2582503509642720453](https://jules.google.com/task/2582503509642720453) started by @jmbish04*