### PR TITLE
🎨 Palette: Enhance RepoFolder quick actions accessibility

### DIFF
--- a/src/frontend/src/components/layout/RepoFolder.tsx
+++ b/src/frontend/src/components/layout/RepoFolder.tsx
@@ -87,19 +87,21 @@ export function RepoFolder({ repo }: RepoFolderProps) {
         </CollapsibleTrigger>
         
         {/* Quick Actions (Hover Only) */}
-        <div className="flex items-center opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="flex items-center opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
           <button 
             onClick={() => isFav ? removeFavorite(repo) : addFavorite(repo)}
-            className="p-1 hover:bg-background rounded-sm"
+            className="p-1 hover:bg-background rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             title={isFav ? "Unfavorite" : "Favorite"}
+            aria-label={isFav ? "Remove from favorites" : "Add to favorites"}
           >
             <Star className={cn("w-3.5 h-3.5", isFav ? "fill-yellow-400 text-yellow-400" : "text-muted-foreground")} />
           </button>
           {!isFav && (
             <button 
               onClick={() => removeFavorite(repo)}
-              className="p-1 hover:bg-background rounded-sm text-muted-foreground hover:text-red-400"
+              className="p-1 hover:bg-background rounded-sm text-muted-foreground hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               title="Close"
+              aria-label={`Remove ${repo.name} from active workspaces`}
             >
               <X className="w-3.5 h-3.5" />
             </button>


### PR DESCRIPTION
## 💡 What
Added robust keyboard accessibility and screen-reader support to the quick actions in `RepoFolder.tsx` (the "Favorite" and "Close" icon buttons).

## 🎯 Why
Previously, the quick actions were revealed using `group-hover:opacity-100` without a corresponding `focus-within:opacity-100`. This meant keyboard users tabbing through the interface would "land" on invisible buttons. Additionally, the icon-only buttons lacked `aria-label`s, making them opaque to screen readers.

## 📸 Before/After
- **Before:** Buttons invisible on focus, missing labels for screen readers.
- **After:** Container becomes fully visible (`opacity-100`) when a child button receives focus (`focus-within:opacity-100`). Both buttons sport semantic `aria-label`s and clear visual focus rings.

## ♿ Accessibility
- Added `focus-within:opacity-100` to the container.
- Added `focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-ring` to the icon-only buttons.
- Added descriptive `aria-label`s reflecting context ("Add to favorites", "Remove from favorites", "Remove [Repo Name] from active workspaces").

---
*PR created automatically by Jules for task [7985438934835723254](https://jules.google.com/task/7985438934835723254) started by @jmbish04*