### PR TITLE
🎨 Palette: Add Accessible Names to Icon-only Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-11 - Add Accessible Names to Icon-only Buttons
+**Learning:** Found a common pattern of missing `aria-label` and `title` attributes on `Button size="icon"` elements across the app. This is a critical accessibility issue, as screen readers announce these buttons simply as "button" with no context about their function. This also hurts usability for sighted users who don't get tooltip hints when hovering over icons (like pencil/edit or check/save).
+**Action:** When adding icon-only buttons, always ensure they include both an `aria-label` for screen readers and a `title` attribute to provide a hover tooltip for sighted users.

--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,35 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => handleSave(field.key, field.type)}
+                        disabled={isSaving}
+                        aria-label={`Save ${field.label}`}
+                        title={`Save ${field.label}`}
+                      >
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={handleCancel}
+                        disabled={isSaving}
+                        aria-label={`Cancel editing ${field.label}`}
+                        title={`Cancel editing ${field.label}`}
+                      >
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => handleEdit(field.key, currentValue)}
+                      aria-label={`Edit ${field.label}`}
+                      title={`Edit ${field.label}`}
+                    >
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the "Save", "Cancel", and "Edit" icon-only buttons within the `ConfigTable` component.

🎯 Why: Icon-only buttons without accessible names are announced simply as "button" by screen readers, providing no context about their function. Adding tooltips also aids sighted users by revealing the action on hover.

📸 Before/After:
Before: `<Button size="icon"><Pencil /></Button>`
After: `<Button size="icon" aria-label="Edit Setting" title="Edit Setting"><Pencil /></Button>`

♿ Accessibility: Ensures that interactive elements provide semantic meaning to assistive technologies and descriptive tooltips for users navigating via mouse or keyboard focus.

---
*PR created automatically by Jules for task [3055298425374429334](https://jules.google.com/task/3055298425374429334) started by @jmbish04*