### PR TITLE
🎨 Palette: Add a11y labels to icon buttons and fix keyboard nav for hover-revealed actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-15 - Hover-Revealed Elements and Keyboard Navigation
+**Learning:** Adding `opacity-0 group-hover:opacity-100` to interactive elements (like icon buttons) hides them visually but doesn't prevent focus, meaning keyboard users can focus an invisible button. However, even if they focus it, it remains invisible unless `focus-within:opacity-100` is used on the parent container.
+**Action:** When implementing hover-revealed UI elements, always move the `opacity-0 group-hover:opacity-100` classes to the parent wrapper and add `focus-within:opacity-100`. Then, add appropriate `focus-visible:ring-1` (or similar focus rings) to the child interactive elements to ensure they become visible and clearly focused during keyboard navigation.

--- a/src/frontend/src/components/chat/chat-interface.tsx
+++ b/src/frontend/src/components/chat/chat-interface.tsx
@@ -163,7 +163,7 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ apiKey, agentId, r
             <div className="w-80 border-r bg-muted/10 flex flex-col">
                 <div className="p-4 border-b flex items-center justify-between bg-background/50 backdrop-blur">
                     <span className="font-semibold text-sm">Discussions</span>
-                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleCreateThread}>
+                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleCreateThread} aria-label="New discussion" title="New discussion">
                         <Plus className="h-4 w-4" />
                     </Button>
                 </div>

--- a/src/frontend/src/views/control/global/Projects.tsx
+++ b/src/frontend/src/views/control/global/Projects.tsx
@@ -186,7 +186,7 @@ export default function Projects() {
                         onChange={e => setSearchQuery(e.target.value)}
                     />
                 </div>
-                <Button variant="outline" size="icon">
+                <Button variant="outline" size="icon" aria-label="Filter projects" title="Filter projects">
                     <Filter className="w-4 h-4" />
                 </Button>
             </div>

--- a/src/frontend/src/views/repos/ProjectsBeta.tsx
+++ b/src/frontend/src/views/repos/ProjectsBeta.tsx
@@ -586,8 +586,8 @@ export default function RepoProjectsTracker() {
                </button>
             </div>
             
-            <div className="w-6 flex justify-end">
-               <Button variant="ghost" size="icon" className="h-6 w-6 text-zinc-500 opacity-0 group-hover:opacity-100 hover:text-zinc-200">
+            <div className="w-6 flex justify-end opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+               <Button variant="ghost" size="icon" className="h-6 w-6 text-zinc-500 hover:text-zinc-200 focus-visible:ring-1" aria-label="More options" title="More options">
                  <MoreHorizontal className="w-4 h-4" />
                </Button>
             </div>


### PR DESCRIPTION
### 💡 What
- Added `aria-label` and `title` attributes to the Filter button in the global Projects view.
- Added `aria-label` and `title` attributes to the "New discussion" button in the Chat interface.
- Fixed keyboard accessibility for the hover-revealed "More options" buttons in the Kanban list view (`ProjectsBeta.tsx`). Moved the `opacity-0 group-hover:opacity-100` classes to a parent wrapper, added `focus-within:opacity-100` to the wrapper, and added `focus-visible:ring-1` to the button itself.
- Documented a critical learning about hover-revealed elements and keyboard navigation in `.Jules/palette.md`.

### 🎯 Why
- **Icon Buttons:** Icon-only buttons without accessible labels are invisible to screen readers, leaving users guessing their function. Titles provide helpful tooltips for sighted users.
- **Hover Reveal:** Hiding interactive elements with `opacity-0` but not `pointer-events-none` allows keyboard users to tab to them, but they remain invisible. Adding `focus-within:opacity-100` ensures these elements become visible when a keyboard user navigates to them, allowing them to know what action they are about to trigger.

### 📸 Before/After
*(Visual changes are internal focus states and tooltips)*
- **Before:** Tabbing through tasks in Kanban view would cause focus to disappear on the invisible "More options" button. Hovering the Filter button showed no tooltip.
- **After:** Tabbing through tasks now reveals the "More options" button with a clear focus ring. Hovering icon buttons shows descriptive tooltips. Screen readers announce the purpose of the buttons.

### ♿ Accessibility
- Ensures all interactive controls have programmatic names (`aria-label`).
- Ensures interactive controls that are hidden by default become visible when focused (`focus-within`, `focus-visible`), satisfying WCAG SC 2.4.7 (Focus Visible) and SC 3.2.1 (On Focus).

---
*PR created automatically by Jules for task [4102432435939254124](https://jules.google.com/task/4102432435939254124) started by @jmbish04*