### PR TITLE
🎨 Palette: Accessibility improvements for icon-only buttons in Todo board

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-02-12 - Accessible Icon-Only Buttons
+**Learning:** Icon-only buttons (like delete, edit, or check marks) without `aria-label` or `title` attributes are completely invisible to screen readers, creating a major accessibility barrier. Similarly, missing focus-visible classes makes them inaccessible to keyboard users.
+**Action:** Always add descriptive `aria-label` and `title` attributes, along with `focus-visible:outline-none focus-visible:ring-2` styles, whenever implementing icon-only interactive elements in the application.

--- a/src/frontend/src/views/control/global/Todo.tsx
+++ b/src/frontend/src/views/control/global/Todo.tsx
@@ -200,6 +200,8 @@ function PostItCard({
         {/* Mark as done */}
         <button
           onClick={() => onMarkDone(note.id)}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black rounded"
+          aria-label="Mark note as done"
           style={{ position: "absolute", top: 6, left: 6, background: "transparent", border: "none", cursor: "pointer", opacity: 0.6, padding: 2, color: "#1a1a1a" }}
           title="Mark done"
         >
@@ -209,6 +211,8 @@ function PostItCard({
         {/* Edit */}
         <button
           onClick={() => onEdit(note.id)}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black rounded"
+          aria-label="Edit note"
           style={{ position: "absolute", top: 6, right: 30, background: "transparent", border: "none", cursor: "pointer", opacity: 0.6, padding: 2, color: "#1a1a1a" }}
           title="Edit note"
         >
@@ -218,6 +222,8 @@ function PostItCard({
         {/* Delete */}
         <button
           onClick={() => onDelete(note.id)}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black rounded"
+          aria-label="Delete note"
           style={{ position: "absolute", top: 6, right: 6, background: "transparent", border: "none", cursor: "pointer", opacity: 0.6, padding: 2, color: "#1a1a1a" }}
           title="Remove note"
         >
@@ -271,6 +277,8 @@ function TornLabel({
         </div>
         <button
           onClick={() => onEdit(label.id)}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black"
+          aria-label="Edit label"
           style={{ position: "absolute", top: -4, right: 20, background: "#333", border: "none", borderRadius: "50%", width: 18, height: 18, color: "#fff", cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.8, zIndex: 10 }}
           title="Edit label"
         >
@@ -278,6 +286,8 @@ function TornLabel({
         </button>
         <button
           onClick={() => onDelete(label.id)}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black"
+          aria-label="Delete label"
           style={{ position: "absolute", top: -4, right: -4, background: "#333", border: "none", borderRadius: "50%", width: 18, height: 18, color: "#fff", cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", opacity: 0.8, zIndex: 10 }}
           title="Remove label"
         >
@@ -582,7 +592,14 @@ export default function TodoPage() {
               <Label style={{ marginBottom: 6, display: "block", fontSize: 12 }}>Color</Label>
               <div style={{ display: "flex", gap: 8 }}>
                 {NOTE_COLORS.map(c => (
-                  <button key={c} onClick={() => setNewColor(c)} style={{ width: 28, height: 28, borderRadius: 4, background: c, border: c === newColor ? "3px solid #fff" : "2px solid transparent", cursor: "pointer", boxShadow: c === newColor ? "0 0 0 1px #888" : "none" }} />
+                  <button
+                    key={c}
+                    onClick={() => setNewColor(c)}
+                    className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+                    aria-label={`Select color ${c}`}
+                    title={`Select color ${c}`}
+                    style={{ width: 28, height: 28, borderRadius: 4, background: c, border: c === newColor ? "3px solid #fff" : "2px solid transparent", cursor: "pointer", boxShadow: c === newColor ? "0 0 0 1px #888" : "none" }}
+                  />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
### 💡 What
Added necessary accessibility attributes (`aria-label`, `title`) and keyboard focus styles (`focus-visible:ring-2`) to icon-only buttons in the Todo board component (`src/frontend/src/views/control/global/Todo.tsx`). Also documented the learning in `.Jules/palette.md`.

### 🎯 Why
Icon-only buttons without aria-labels are invisible to screen readers, and buttons without focus styles cannot be effectively used by keyboard-only users. These small changes bring the UI up to standard accessibility requirements.

### 📸 Before/After
**Before:**
Icon-only buttons could not be tabbed to gracefully and offered no context to screen reading devices. 

**After:**
All icon-only buttons now show descriptive text on hover (title), announce their purpose to screen readers (aria-label), and prominently highlight when navigating via the keyboard (Tab).

### ♿ Accessibility
- Added `aria-label`s to Edit, Delete, and Mark Done icons.
- Added `focus-visible:ring-2` to support keyboard tabbing.
- Ensured color selectors announce which color they represent.

---
*PR created automatically by Jules for task [1456965967223735857](https://jules.google.com/task/1456965967223735857) started by @jmbish04*