### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to ConfigTable icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-22 - [Add missing ARIA labels and titles to ConfigTable icon buttons]
+**Learning:** Icon-only buttons using generic components like `<Button size="icon">` lack accessibility descriptions by default and must explicitly be provided `aria-label` and `title` properties. This not only makes them screen reader accessible, but also provides a necessary tooltip on hover to clarify functionality.
+**Action:** When adding or auditing icon-only buttons, always ensure they have a clear `aria-label` and `title` set.

--- a/src/frontend/src/components/config/ConfigTable.tsx
+++ b/src/frontend/src/components/config/ConfigTable.tsx
@@ -132,15 +132,15 @@ export function ConfigTable({ data, fields, onSave }: ConfigTableProps) {
                 <TableCell className="text-right">
                   {isEditing ? (
                     <div className="flex justify-end gap-2">
-                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={() => handleSave(field.key, field.type)} disabled={isSaving} aria-label="Save" title="Save">
                         <Check className="h-4 w-4 text-green-500" />
                       </Button>
-                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving}>
+                      <Button size="icon" variant="ghost" onClick={handleCancel} disabled={isSaving} aria-label="Cancel" title="Cancel">
                         <X className="h-4 w-4 text-red-500" />
                       </Button>
                     </div>
                   ) : (
-                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)}>
+                    <Button size="icon" variant="ghost" onClick={() => handleEdit(field.key, currentValue)} aria-label="Edit" title="Edit">
                       <Pencil className="h-4 w-4" />
                     </Button>
                   )}


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to the icon-only buttons (Save, Cancel, Edit) within the `ConfigTable` component.
🎯 **Why:** To ensure that screen readers can accurately announce the purpose of these action buttons and to provide standard hover tooltips for visual users, improving both accessibility and general usability.
📸 **Before/After:** The buttons previously had no text or aria labels, making them inaccessible. They now have descriptive labels ("Save", "Cancel", "Edit").
♿ **Accessibility:** Fixes a critical accessibility failure where interactive icon-only elements lacked an accessible name, making them unusable for assistive technologies.

---
*PR created automatically by Jules for task [12125475496021762116](https://jules.google.com/task/12125475496021762116) started by @jmbish04*