### PR TITLE
fix: correctly utilize DO SQLite in PrManagerAgent

### DIFF
--- a/src/backend/src/ai/agents/JulesOverseer.ts
+++ b/src/backend/src/ai/agents/JulesOverseer.ts
@@ -183,7 +183,6 @@ export class JulesOverseer extends JulesOverseerDurableObject {
         if (payload.type === 'insight') {
           const db = getDb(this.env.DB);
           await db.insert(learningAiInsights).values({
-          await db.insert(learningAiInsights).values({
             id: crypto.randomUUID(),
             sessionId: payload.sessionId,
             patternType: payload.patternType || 'anti_pattern',
@@ -229,7 +228,6 @@ export class JulesOverseer extends JulesOverseerDurableObject {
 
       await julesService.sendMessage(sessionId, OVERRIDE_MESSAGE);
 
-      await db.insert(learningAiInsights).values({
       await db.insert(learningAiInsights).values({
         id: crypto.randomUUID(),
         sessionId,

--- a/src/backend/src/ai/agents/pr-manager/PrManagerAgent.ts
+++ b/src/backend/src/ai/agents/pr-manager/PrManagerAgent.ts
@@ -47,7 +47,7 @@ export class PrManagerAgent extends runtime.Agent {
     }
     if (url.pathname === '/api/jobs') {
       await this.onStart();
-      const results = this.sql.prepare("SELECT * FROM pr_manager_jobs ORDER BY created_at DESC LIMIT 50").all();
+      const results = Array.from(this.ctx.storage.sql.exec("SELECT * FROM pr_manager_jobs ORDER BY created_at DESC LIMIT 50"));
       return new Response(JSON.stringify(results), {
         headers: { 'Content-Type': 'application/json' }
       });
@@ -57,7 +57,7 @@ export class PrManagerAgent extends runtime.Agent {
 
   async onStart() {
     // DO SQLite state management init
-    this.sql.prepare(`
+    this.ctx.storage.sql.exec(`
       CREATE TABLE IF NOT EXISTS pr_manager_jobs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         owner TEXT NOT NULL,
@@ -67,15 +67,15 @@ export class PrManagerAgent extends runtime.Agent {
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )
-    `).run();
+    `);
   }
 
   async scheduled() {
     console.log('[PrManagerAgent] Running scheduled PR scan...');
     // Ensure agent state is initialized
     await this.onStart();
-    const owner = this.env.TEST_REPO_OWNER || 'cloudflare';
-    const repo = this.env.TEST_REPO_NAME || 'core-github-api';
+    const owner = this.env.GITHUB_OWNER || 'cloudflare';
+    const repo = this.env.HEALTH_TEST_REPO_NAME || 'core-github-api';
 
     await setupOpenAIAgentClient(this.env, "workers-ai");
 
@@ -191,24 +191,24 @@ Output a JSON object with:
               if (!allResolved) {
                 console.log(`[PrManagerAgent] Low confidence in resolving PR #${pr.number}. Adding comment.`);
                 await octokit.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: "I am unable to confidently resolve these conflicts automatically. Manual intervention is required." });
-                this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_commented', Date.now(), Date.now()).run();
+                this.ctx.storage.sql.exec('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)', owner, repo, pr.number, 'conflict_commented', Date.now(), Date.now());
                 await execInSandbox('git merge --abort');
               } else {
                  console.log(`[PrManagerAgent] High confidence in resolving PR #${pr.number}. Pushing merge commit...`);
                  await execInSandbox('git add .');
                  await execInSandbox('git commit -m "Auto-resolved merge conflicts"');
                  await execInSandbox(`git push origin ${headRef}`);
-                 this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now()).run();
+                 this.ctx.storage.sql.exec('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)', owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now());
               }
             } else {
                // Merge succeeded cleanly? Should not happen if mergeable_state === 'dirty', but handle just in case
                console.log(`[PrManagerAgent] Merge surprisingly succeeded without conflicts for PR #${pr.number}`);
                await execInSandbox(`git push origin ${headRef}`);
-               this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now()).run();
+               this.ctx.storage.sql.exec('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)', owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now());
             }
           } catch (err) {
              console.error(`[PrManagerAgent] Failed to merge PR #${pr.number}:`, err);
-             this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_failed', Date.now(), Date.now()).run();
+             this.ctx.storage.sql.exec('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)', owner, repo, pr.number, 'conflict_failed', Date.now(), Date.now());
           } finally {
              // Let Sandbox terminate normally, no explicit cleanup needed here unless requested.
           }


### PR DESCRIPTION
### 🎯 What
Fixes a hallucination in `PrManagerAgent` where it attempted to interact with its embedded DO SQLite storage using D1 APIs (`.prepare()`, `.bind()`, `.run()`, `.all()`), which are not supported by the `SqlStorage` runtime. 

### 🛠️ Solution
- Replaced all invalid `this.sql.prepare()...` chains with `this.ctx.storage.sql.exec(query, ...bindings)`.
- Replaced invalid `.all()` reads with `Array.from()` to parse the iterable cursor returned by `exec`.
- Fixed a syntax error in `JulesOverseer.ts` caused by duplicate line insertions that broke `tsc --noEmit`.
- Mapped environment variables (`TEST_REPO_OWNER`, `TEST_REPO_NAME`) to their correct counterparts found in `worker-configuration.d.ts` (`GITHUB_OWNER`, `HEALTH_TEST_REPO_NAME`).

### ⚠️ Risk
Low. The logic now conforms correctly to the Cloudflare Agents SDK/Durable Objects internal storage API. The agent will now successfully persist PR tracking jobs without throwing internal server errors during `onStart` or `/scheduled` invocations.

---
*PR created automatically by Jules for task [18365788045356804099](https://jules.google.com/task/18365788045356804099) started by @jmbish04*