### PR TITLE
Align research workflow dispatch contract

### DIFF
--- a/src/backend/src/routes/api/frontend/research/one-time.ts
+++ b/src/backend/src/routes/api/frontend/research/one-time.ts
@@ -24,6 +24,10 @@ function cString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
+function hasDbBinding(env: unknown): env is { DB: unknown } {
+  return typeof env === 'object' && env !== null && 'DB' in env;
+}
+
 function resolveResearchQueueRepo(env: Env) {
   const configuredRepo = cString(env.RESEARCH_QUEUE_REPO_NAME) || 'jmbish04/core-github-research';
   const [owner, repo] = configuredRepo.includes('/')
@@ -41,8 +45,25 @@ function resolveResearchQueueRepo(env: Env) {
   };
 }
 
-function buildResearchCallbackUrl(c: ResearchRouteContext): string {
-  return `${cString(c.env.BASE_URL) || new URL(c.req.url).origin}/api/research/callback`;
+export function buildResearchCallbackUrl(c: ResearchRouteContext): string {
+  const baseUrl = cString(c.env.BASE_URL);
+  if (baseUrl) {
+    return `${baseUrl.replace(/\/+$/, '')}/api/research/callback`;
+  }
+
+  try {
+    return `${new URL(c.req.url).origin}/api/research/callback`;
+  } catch {
+    const host = c.req.header('host') || 'localhost';
+    const forwardedProto = c.req.header('x-forwarded-proto');
+    const protocol =
+      forwardedProto === 'https' || forwardedProto === 'http'
+        ? forwardedProto
+        : typeof c.req.url === 'string' && c.req.url.startsWith('https://')
+          ? 'https'
+          : 'http';
+    return `${protocol}://${host}/api/research/callback`;
+  }
 }
 
 function normalizeStringList(value: unknown): string[] {
@@ -84,11 +105,24 @@ async function dispatchResearchWorkflow(
 }
 
 async function handleResearchWorkflowCallback(c: ResearchRouteContext, routeProjectId?: string) {
-  const db = getDb(c.env.DB);
   const logger = new Logger(c.env, 'ResearchPipeline');
+  let rawPayload: Record<string, unknown> | null | undefined;
 
   try {
-    const rawPayload = (await c.req.json()) as Record<string, unknown>;
+    rawPayload = await c.req.json<Record<string, unknown>>();
+  } catch (error) {
+    logger.warn('Invalid JSON payload in research callback', {
+      routeProjectId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    if (hasDbBinding(c.env)) {
+      await logger.flush();
+    }
+    return c.json({ error: 'Invalid JSON payload' }, 400);
+  }
+
+  try {
+    const db = getDb(c.env.DB);
     const callback = normalizeResearchWorkflowCallback(rawPayload, routeProjectId);
 
     logger.info('Received research workflow callback', {

--- a/src/backend/src/routes/api/frontend/research/one-time.ts
+++ b/src/backend/src/routes/api/frontend/research/one-time.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { getDb } from '@db';
 import { researchProjects, researchReports } from '@/db/schemas/github/research';
 import { eq, desc } from 'drizzle-orm';
@@ -8,7 +8,151 @@ import { createDiscordApiClient } from '@/services/discord/client';
 import { Logger } from '@/lib/logger';
 import { getGithubToken } from '@/utils/secrets';
 import { HoniClient } from '@utils/honi-client';
+import {
+  buildResearchDispatchPlan,
+  buildResearchOrchestrationPrompt,
+  type ResearchWorkflowDispatchPlan,
+  normalizeResearchWorkflowCallback,
+} from './workflow-contract';
+
 const app = new Hono<{ Bindings: Env }>();
+
+type ResearchRouteContext = Context<{ Bindings: Env }>;
+type DiagnosticDispatchMode = 'targeted' | 'keyword' | 'both';
+
+function cString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function resolveResearchQueueRepo(env: Env) {
+  const configuredRepo = cString(env.RESEARCH_QUEUE_REPO_NAME) || 'jmbish04/core-github-research';
+  const [owner, repo] = configuredRepo.includes('/')
+    ? configuredRepo.split('/', 2)
+    : [cString(env.GITHUB_OWNER) || 'jmbish04', configuredRepo];
+  const fullName = `${owner}/${repo}`;
+
+  return {
+    owner,
+    repo,
+    fullName,
+    dispatcherUri:
+      cString(env.RESEARCH_QUEUE_REPO_DISPATCHER_URI) ||
+      `https://api.github.com/repos/${fullName}/dispatches`,
+  };
+}
+
+function buildResearchCallbackUrl(c: ResearchRouteContext): string {
+  return `${cString(c.env.BASE_URL) || new URL(c.req.url).origin}/api/research/callback`;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter(Boolean);
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+async function dispatchResearchWorkflow(
+  dispatcherUri: string,
+  payload: Record<string, unknown>,
+  ghToken: string,
+) {
+  const res = await fetch(dispatcherUri, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github.v3+json',
+      Authorization: `token ${ghToken}`,
+      'User-Agent': 'Core-GitHub-API-Research',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Research dispatch failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function handleResearchWorkflowCallback(c: ResearchRouteContext, routeProjectId?: string) {
+  const db = getDb(c.env.DB);
+  const logger = new Logger(c.env, 'ResearchPipeline');
+
+  try {
+    const rawPayload = (await c.req.json()) as Record<string, unknown>;
+    const callback = normalizeResearchWorkflowCallback(rawPayload, routeProjectId);
+
+    logger.info('Received research workflow callback', {
+      callbackEvent: callback.event,
+      mode: callback.mode,
+      projectId: callback.projectId,
+      taskId: callback.taskId,
+      path: callback.path,
+      resultsFile: callback.resultsFile,
+      status: callback.status,
+      clonedRepos: callback.clonedRepos,
+      discoveredRepos: callback.discoveredRepos,
+      newDiscoveredRepos: callback.newDiscoveredRepos,
+    });
+
+    const project = await db
+      .select()
+      .from(researchProjects)
+      .where(eq(researchProjects.id, callback.projectId))
+      .get();
+
+    if (!project) {
+      logger.warn('Ignoring research callback for unknown project', {
+        routeProjectId,
+        projectId: callback.projectId,
+        taskId: callback.taskId,
+      });
+      await logger.flush();
+      return c.json({ success: true, ignored: true, callback });
+    }
+
+    const nextStatus =
+      callback.status === 'error' || callback.status === 'failed'
+        ? 'failed'
+        : callback.mode === 'health'
+          ? 'active'
+          : 'analyzing';
+
+    await db
+      .update(researchProjects)
+      .set({ status: nextStatus, updatedAt: new Date() })
+      .where(eq(researchProjects.id, callback.projectId));
+
+    if (callback.mode !== 'health' && nextStatus !== 'failed') {
+      const queueRepo = resolveResearchQueueRepo(c.env);
+      await HoniClient.chat(
+        c.env.AGENT_SESSION_DO,
+        `research-orch-${callback.projectId}`,
+        buildResearchOrchestrationPrompt(queueRepo.fullName, callback),
+      );
+    }
+
+    await logger.flush();
+    return c.json({ success: true, callback, nextStatus });
+  } catch (error: any) {
+    logger.error('Research callback failed', {
+      projectId: routeProjectId,
+      error: error.message,
+      stack: error.stack,
+    });
+    await logger.flush();
+    return c.json({ error: error.message }, 500);
+  }
+}
 
 // 1. Get Projects by Type
 app.get('/projects', async (c) => {
@@ -25,7 +169,7 @@ app.post('/projects/draft', async (c) => {
   const { type } = await c.req.json();
   const db = getDb(c.env.DB);
   const id = uuidv4();
-  
+
   await db.insert(researchProjects).values({
     id,
     type: type || 'custom',
@@ -33,7 +177,7 @@ app.post('/projects/draft', async (c) => {
     title: '',
     githubTerms: [],
     discordTerms: [],
-    googleTerms: []
+    googleTerms: [],
   });
 
   return c.json({ id });
@@ -44,16 +188,19 @@ app.put('/projects/:id', async (c) => {
   const id = c.req.param('id');
   const body = await c.req.json();
   const db = getDb(c.env.DB);
-  
+
   const updateData = { ...body };
   delete updateData.id;
   delete updateData.createdAt;
   delete updateData.updatedAt;
-  
-  await db.update(researchProjects).set({
-    ...updateData,
-    updatedAt: new Date()
-  }).where(eq(researchProjects.id, id));
+
+  await db
+    .update(researchProjects)
+    .set({
+      ...updateData,
+      updatedAt: new Date(),
+    })
+    .where(eq(researchProjects.id, id));
 
   return c.json({ success: true });
 });
@@ -61,20 +208,22 @@ app.put('/projects/:id', async (c) => {
 // 4. Get Distinct Search Terms from historical projects
 app.get('/terms/distinct', async (c) => {
   const db = getDb(c.env.DB);
-  const projects = await db.select({ 
-    github: researchProjects.githubTerms, 
-    discord: researchProjects.discordTerms, 
-    google: researchProjects.googleTerms 
-  }).from(researchProjects);
+  const projects = await db
+    .select({
+      github: researchProjects.githubTerms,
+      discord: researchProjects.discordTerms,
+      google: researchProjects.googleTerms,
+    })
+    .from(researchProjects);
 
   const gh = new Set<string>();
   const ds = new Set<string>();
   const go = new Set<string>();
 
-  projects.forEach(p => {
-    if (Array.isArray(p.github)) p.github.forEach(t => gh.add(t));
-    if (Array.isArray(p.discord)) p.discord.forEach(t => ds.add(t));
-    if (Array.isArray(p.google)) p.google.forEach(t => go.add(t));
+  projects.forEach((p) => {
+    if (Array.isArray(p.github)) p.github.forEach((t) => gh.add(t));
+    if (Array.isArray(p.discord)) p.discord.forEach((t) => ds.add(t));
+    if (Array.isArray(p.google)) p.google.forEach((t) => go.add(t));
   });
 
   return c.json({ github: Array.from(gh), discord: Array.from(ds), google: Array.from(go) });
@@ -85,62 +234,70 @@ app.get('/projects/:id/details', async (c) => {
   const id = c.req.param('id');
   const db = getDb(c.env.DB);
   const project = await db.select().from(researchProjects).where(eq(researchProjects.id, id)).get();
-  const reports = await db.select().from(researchReports).where(eq(researchReports.projectId, id)).orderBy(desc(researchReports.createdAt)).limit(1);
+  const reports = await db
+    .select()
+    .from(researchReports)
+    .where(eq(researchReports.projectId, id))
+    .orderBy(desc(researchReports.createdAt))
+    .limit(1);
   return c.json({ project, latestReport: reports[0] || null });
 });
 
 // 6. Get all reports grouped by Project (For Daily Trends Tab)
 app.get('/reports', async (c) => {
   const db = getDb(c.env.DB);
-  // Implement a JOIN to return reports alongside their parent project title/goal
-  const data = await db.select({
-    reportId: researchReports.id,
-    createdAt: researchReports.createdAt,
-    projectTitle: researchProjects.title,
-    projectId: researchProjects.id,
-    findings: researchReports.findings
-  }).from(researchReports).leftJoin(researchProjects, eq(researchReports.projectId, researchProjects.id)).orderBy(desc(researchReports.createdAt));
-  
-  return c.json(data); 
+  const data = await db
+    .select({
+      reportId: researchReports.id,
+      createdAt: researchReports.createdAt,
+      projectTitle: researchProjects.title,
+      projectId: researchProjects.id,
+      findings: researchReports.findings,
+    })
+    .from(researchReports)
+    .leftJoin(researchProjects, eq(researchReports.projectId, researchProjects.id))
+    .orderBy(desc(researchReports.createdAt));
+
+  return c.json(data);
 });
 
 // 7. Translate natural language to Cron expression
 app.post('/cron/translate', async (c) => {
   const { prompt } = await c.req.json();
   const ai = c.env.AI as any;
-  
+
   const systemPrompt = `
     You are a strict Cloudflare Worker cron schedule expression generator. 
     The user will provide a desired schedule in natural language. 
     Return a JSON object with a single key 'cron' containing the standard 5-part cron expression (minute hour day month day-of-week). 
     No other text. For example, "Run every day at 8am" should be converted to "0 8 * * *".
   `;
-  
+
   try {
     const response = await ai.run('@cf/meta/llama-3.3-70b-instruct-fp8-fast', {
       messages: [
         { role: 'system', content: systemPrompt },
-        { role: 'user', content: prompt }
+        { role: 'user', content: prompt },
       ],
       response_format: {
-          type: 'json_schema',
-          json_schema: {
-            type: "object",
-            properties: {
-              cron: { type: "string" }
-            },
-            required: ["cron"]
-          }
-      }
+        type: 'json_schema',
+        json_schema: {
+          type: 'object',
+          properties: {
+            cron: { type: 'string' },
+          },
+          required: ['cron'],
+        },
+      },
     });
-    
-    let result = (response as any);
+
+    let result = response as any;
     if (result.response && typeof result.response === 'string') {
       result = JSON.parse(result.response);
     } else if (typeof result === 'string') {
       result = JSON.parse(result);
     }
-    
+
     return c.json({ cron: result.cron });
   } catch (e) {
     console.error('Failed to parse cron:', e);
@@ -158,22 +315,22 @@ Output a JSON object with "githubTerms" (array of 3 strings for GitHub repo sear
     const response = await ai.run('@cf/meta/llama-3.3-70b-instruct-fp8-fast', {
       messages: [{ role: 'user', content: prompt }],
       response_format: {
-          type: 'json_schema',
-          json_schema: {
-            type: "object",
-            properties: {
-              githubTerms: { type: "array", items: { type: "string" } },
-              discordTerms: { type: "array", items: { type: "string" } }
-            },
-            required: ["githubTerms", "discordTerms"]
-          }
-      }
+        type: 'json_schema',
+        json_schema: {
+          type: 'object',
+          properties: {
+            githubTerms: { type: 'array', items: { type: 'string' } },
+            discordTerms: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['githubTerms', 'discordTerms'],
+        },
+      },
     });
-    let result = (response as any);
+    let result = response as any;
     if (result.response && typeof result.response === 'string') result = JSON.parse(result.response);
     else if (typeof result === 'string') result = JSON.parse(result);
     return c.json({ githubTerms: result.githubTerms || [], discordTerms: result.discordTerms || [] });
-  } catch(e: any) {
+  } catch (e: any) {
     return c.json({ error: e.message }, 500);
   }
 });
@@ -188,19 +345,19 @@ Output a JSON object with a single string field "query" that represents the core
     const response = await ai.run('@cf/meta/llama-3.3-70b-instruct-fp8-fast', {
       messages: [{ role: 'user', content: prompt }],
       response_format: {
-          type: 'json_schema',
-          json_schema: {
-            type: "object",
-            properties: { query: { type: "string" } },
-            required: ["query"]
-          }
-      }
+        type: 'json_schema',
+        json_schema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
     });
-    let result = (response as any);
+    let result = response as any;
     if (result.response && typeof result.response === 'string') result = JSON.parse(result.response);
     else if (typeof result === 'string') result = JSON.parse(result);
-    return c.json({ query: result.query || "" });
-  } catch(e: any) {
+    return c.json({ query: result.query || '' });
+  } catch (e: any) {
     return c.json({ error: e.message }, 500);
   }
 });
@@ -209,67 +366,62 @@ Output a JSON object with a single string field "query" that represents the core
 app.post('/test', async (c) => {
   const { githubTerms, discordTerms } = await c.req.json();
   const ai = c.env.AI as any;
-  
+
   const results: any = {
     github: [],
     discord: [],
-    aiInterpretation: ""
+    aiInterpretation: '',
   };
 
   try {
-    // 1. Test GitHub Terms
     if (githubTerms && githubTerms.length > 0) {
       const octokit = await getOctokit(c.env as any);
-      
-      // We'll just test the first term to keep the preview fast
       const term = githubTerms[0];
-      
+
       const searchRes = await octokit.rest.search.repos({
         q: term,
         sort: 'stars',
-        per_page: 3
+        per_page: 3,
       });
-      
+
       results.github = searchRes.data.items.map((item: any) => ({
         name: item.full_name,
         url: item.html_url,
         description: item.description,
         stars: item.stargazers_count,
-        topics: item.topics
+        topics: item.topics,
       }));
     }
 
-    // 2. Test Discord Terms using the new API Client
     if (discordTerms && discordTerms.length > 0) {
       try {
         const discord = await createDiscordApiClient(c.env as Env);
-          const guilds = await discord.getGuilds();
-          const searchRegex = new RegExp(discordTerms[0], 'i');
-          
-          // Just scan the first available text channel for a quick preview
-          if (guilds.length > 0) {
-            const channels = await discord.getGuildChannels(guilds[0].id);
-            const textChannels = channels.filter(ch => ch.type === 0);
-            
-            if (textChannels.length > 0) {
-              const messages = await discord.getChannelMessages(textChannels[0].id, 100);
-              const matched = messages.filter(m => searchRegex.test(m.content)).slice(0, 3);
-              
-              results.discord = matched.map((m: any) => ({
-                 channel: textChannels[0].name || textChannels[0].id,
-                 content: m.content,
-                 author: m.author?.username || 'unknown'
-              }));
-            }
+        const guilds = await discord.getGuilds();
+        const searchRegex = new RegExp(discordTerms[0], 'i');
+
+        if (guilds.length > 0) {
+          const channels = await discord.getGuildChannels(guilds[0].id);
+          const textChannels = channels.filter((ch) => ch.type === 0);
+
+          if (textChannels.length > 0) {
+            const messages = await discord.getChannelMessages(textChannels[0].id, 100);
+            const matched = messages.filter((m) => searchRegex.test(m.content)).slice(0, 3);
+
+            results.discord = matched.map((m: any) => ({
+              channel: textChannels[0].name || textChannels[0].id,
+              content: m.content,
+              author: m.author?.username || 'unknown',
+            }));
           }
+        }
       } catch (err) {
         console.warn('Discord test fetch failed:', err);
-        results.discord = [{ channel: "error", content: "Failed to connect to Discord API.", author: "system" }];
+        results.discord = [
+          { channel: 'error', content: 'Failed to connect to Discord API.', author: 'system' },
+        ];
       }
     }
 
-    // 3. AI Interpretation
-    // Give the AI a quick summary of what was found and ask it to interpret if it matches the vibe
     if (results.github.length > 0 || results.discord.length > 0) {
       const summaryContext = `
         GitHub Findings: ${JSON.stringify(results.github, null, 2)}
@@ -284,20 +436,20 @@ Findings:
 ${summaryContext}`;
 
       const aiResponse = await ai.run('@cf/meta/llama-3.1-8b-instruct', {
-          messages: [{ role: 'user', content: prompt }]
+        messages: [{ role: 'user', content: prompt }],
       });
-      
-      const interpretation = (aiResponse as any).response || "Could not generate interpretation.";
+
+      const interpretation = (aiResponse as any).response || 'Could not generate interpretation.';
       results.aiInterpretation = interpretation.trim();
     } else {
-      results.aiInterpretation = "No results found for these terms. You may want to broaden your search.";
+      results.aiInterpretation =
+        'No results found for these terms. You may want to broaden your search.';
     }
 
     return c.json(results);
-
   } catch (error: any) {
-    console.error("Test search failed:", error);
-    return c.json({ error: "Search test failed", details: error.message }, 500);
+    console.error('Test search failed:', error);
+    return c.json({ error: 'Search test failed', details: error.message }, 500);
   }
 });
 
@@ -310,199 +462,215 @@ app.post('/projects/:id/trigger', async (c) => {
   try {
     const project = await db.select().from(researchProjects).where(eq(researchProjects.id, id)).get();
     if (!project) {
-        logger.error('Project not found for trigger', { projectId: id });
-        await logger.flush();
-        return c.json({ error: 'Not found' }, 404);
+      logger.error('Project not found for trigger', { projectId: id });
+      await logger.flush();
+      return c.json({ error: 'Not found' }, 404);
     }
 
     logger.info('Research pipeline triggered', { projectId: id, type: project.type });
-    let discordContext = "";
-    
-    // Test Discord Terms using the API Client
+    let discordContext = '';
+
     if (project.discordTerms && project.discordTerms.length > 0) {
       try {
         const discord = await createDiscordApiClient(c.env as Env);
         const guilds = await discord.getGuilds();
-        
+
         let allMatched: any[] = [];
-        
+
         for (const term of project.discordTerms) {
           const searchRegex = new RegExp(term, 'i');
           if (guilds.length > 0) {
-              const channels = await discord.getGuildChannels(guilds[0].id);
-              const textChannels = channels.filter((ch: any) => ch.type === 0);
-              
-              if (textChannels.length > 0) {
-                const messages = await discord.getChannelMessages(textChannels[0].id, 100);
-                const matched = messages.filter((m: any) => searchRegex.test(m.content));
-                allMatched = [...allMatched, ...matched];
-              }
+            const channels = await discord.getGuildChannels(guilds[0].id);
+            const textChannels = channels.filter((ch: any) => ch.type === 0);
+
+            if (textChannels.length > 0) {
+              const messages = await discord.getChannelMessages(textChannels[0].id, 100);
+              const matched = messages.filter((m: any) => searchRegex.test(m.content));
+              allMatched = [...allMatched, ...matched];
+            }
           }
         }
-        
+
         if (allMatched.length > 0) {
-            discordContext = allMatched.map(m => `**Author:** ${m.author?.username || 'unknown'}\n**Message:** ${m.content}\n---`).join('\n');
-            logger.info('Extracted Discord context for staging', { matchedCount: allMatched.length });
+          discordContext = allMatched
+            .map((m) => `**Author:** ${m.author?.username || 'unknown'}\n**Message:** ${m.content}\n---`)
+            .join('\n');
+          logger.info('Extracted Discord context for staging', { matchedCount: allMatched.length });
         }
       } catch (err: any) {
         logger.error('Discord fetch failed during trigger', { error: err.message });
       }
     }
 
-    const octokit = await getOctokit(c.env as Env);
-    const queueRepo = c.env.RESEARCH_QUEUE_REPO_NAME || 'jmbish04/core-github-research'; // Format: "jmbish04/core-github-research"
-    const [owner, repo] = queueRepo.split('/');
-    
-    // If we have discord context, push it to the queue repo
+    const queueRepo = resolveResearchQueueRepo(c.env);
     if (discordContext) {
-        logger.info('Pushing Discord context to staging repo', { repo: queueRepo });
-        const path = `daily-research/${project.id}/discord/raw-export.md`;
-        
-        // Check if file exists to get SHA
-        let sha;
-        try {
-            const { data } = await octokit.rest.repos.getContent({ owner, repo, path });
-            if (!Array.isArray(data)) sha = (data as any).sha;
-        } catch { /* sha lookup may fail for new files */ }
-        
-        await octokit.rest.repos.createOrUpdateFileContents({
-            owner,
-            repo,
-            path,
-            message: `🚀 Stage Discord Research data for ${project.id}`,
-            content: btoa(unescape(encodeURIComponent(discordContext))),
-            sha
+      const octokit = await getOctokit(c.env as Env);
+      logger.info('Pushing Discord context to staging repo', { repo: queueRepo.fullName });
+      const path = `daily-research/${project.id}/discord/raw-export.md`;
+
+      let sha;
+      try {
+        const { data } = await octokit.rest.repos.getContent({
+          owner: queueRepo.owner,
+          repo: queueRepo.repo,
+          path,
         });
+        if (!Array.isArray(data)) sha = (data as any).sha;
+      } catch {
+        // sha lookup may fail for new files
+      }
+
+      await octokit.rest.repos.createOrUpdateFileContents({
+        owner: queueRepo.owner,
+        repo: queueRepo.repo,
+        path,
+        message: `🚀 Stage Discord Research data for ${project.id}`,
+        content: btoa(unescape(encodeURIComponent(discordContext))),
+        sha,
+      });
     }
 
-    // Output Github repos
-    let githubReposToDispatch: string[] = [];
-    if (project.githubTerms && project.githubTerms.length > 0) {
-        for (const term of project.githubTerms) {
-            const searchRes = await octokit.rest.search.repos({
-                q: term,
-                sort: 'stars',
-                per_page: 5
-            });
-            githubReposToDispatch = [...githubReposToDispatch, ...searchRes.data.items.map((i: any) => i.full_name)];
-        }
-    }
-    
-    // Deduplicate
-    githubReposToDispatch = [...new Set(githubReposToDispatch)];
-
-    // Dispatch a workflow to jmbish04/core-github-research
-    logger.info('Dispatching github action dispatcher', { repo: queueRepo, reposToProcess: githubReposToDispatch.length });
-    const ghToken = await getGithubToken(c.env);
-    const dispatcherUri = c.env.RESEARCH_QUEUE_REPO_DISPATCHER_URI || `https://api.github.com/repos/${queueRepo}/dispatches`;
-
-    await fetch(dispatcherUri, {
-        method: "POST",
-        headers: {
-            "Accept": "application/vnd.github.v3+json",
-            "Authorization": `Bearer ${ghToken}`,
-            "User-Agent": "Core-GitHub-API-Research",
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-            event_type: "research-dispatcher-start",
-            client_payload: {
-                project_id: id,
-                target_repos: githubReposToDispatch.join(','),
-                timestamp: new Date().toISOString()
-            }
-        })
+    const dispatchPlan = buildResearchDispatchPlan({
+      callbackUrl: buildResearchCallbackUrl(c),
+      githubTerms: project.githubTerms,
+      goal: project.goal,
+      googleTerms: project.googleTerms,
+      projectId: id,
+      taskId: id,
     });
 
-    await db.update(researchProjects).set({ status: 'in_progress', updatedAt: new Date() }).where(eq(researchProjects.id, id));
-    
+    logger.info('Dispatching research workflow', {
+      callbackUrl: cString(dispatchPlan.payload.client_payload.callback_url),
+      keywordTerms: dispatchPlan.keywordTerms,
+      mode: dispatchPlan.mode,
+      repo: queueRepo.fullName,
+      targetedRepos: dispatchPlan.targetedRepos,
+    });
+
+    const ghToken = await getGithubToken(c.env);
+    if (!ghToken) {
+      throw new Error('Missing GitHub token for research dispatch');
+    }
+
+    await dispatchResearchWorkflow(queueRepo.dispatcherUri, dispatchPlan.payload, ghToken);
+
+    await db
+      .update(researchProjects)
+      .set({ status: 'in_progress', updatedAt: new Date() })
+      .where(eq(researchProjects.id, id));
+
     await logger.flush();
-    return c.json({ success: true, message: 'Pipeline dispatched' });
-  } catch(error: any) {
+    return c.json({
+      success: true,
+      message: 'Pipeline dispatched',
+      mode: dispatchPlan.mode,
+      callbackUrl: dispatchPlan.payload.client_payload.callback_url,
+      keywordTerms: dispatchPlan.keywordTerms,
+      targetedRepos: dispatchPlan.targetedRepos,
+    });
+  } catch (error: any) {
     logger.error('Research pipeline failed', { projectId: id, error: error.message, stack: error.stack });
     await logger.flush();
     return c.json({ error: error.message }, 500);
   }
 });
 
-// 10. Callback from GitHub Action
+// 10. Callback from GitHub Action. `/callback` matches the current workflow contract,
+// while `/projects/:id/callback` remains as the legacy per-project alias.
+app.post('/callback', async (c) => handleResearchWorkflowCallback(c));
 app.post('/projects/:id/callback', async (c) => {
-  const id = c.req.param('id');
-  const db = getDb(c.env.DB);
-  const logger = new Logger(c.env, 'ResearchPipeline');
-  
-  try {
-     logger.info('Received callback from Action dispatcher', { projectId: id });
-     
-     // Update status
-     await db.update(researchProjects).set({ status: 'analyzing', updatedAt: new Date() }).where(eq(researchProjects.id, id));
-     
-     const queueRepo = c.env.RESEARCH_QUEUE_REPO_NAME || 'jmbish04/core-github-research';
-     
-     // Invoke the Agent Research by fetching to its endpoint (using HoniClient DO binding)
-     await HoniClient.chat(c.env.AGENT_SESSION_DO, `research-orch-${id}`,
-         `Begin Jules orchestration for research task ${id} located in daily-research/${id}/ on repo ${queueRepo}`
-     );
-     
-     await logger.flush();
-     return c.json({ success: true });
-  } catch(error: any) {
-     logger.error('Research callback failed', { projectId: id, error: error.message });
-     await logger.flush();
-     return c.json({ error: error.message }, 500);
-  }
+  return handleResearchWorkflowCallback(c, c.req.param('id'));
 });
+
 // 11. Workflow Diagnostics - Dispatcher Test
 app.post('/test-dispatch', async (c) => {
   const logger = new Logger(c.env, 'ResearchPipeline');
   try {
-     const testId = `test-${Date.now()}`;
-     const repo = c.env.RESEARCH_QUEUE_REPO_NAME || 'jmbish04/core-github-research';
-     const dispatcherUri = c.env.RESEARCH_QUEUE_REPO_DISPATCHER_URI || `https://api.github.com/repos/${repo}/dispatches`;
+    const requestBody = c.req.header('content-type')?.includes('application/json')
+      ? ((await c.req.json().catch(() => ({}))) as Record<string, unknown>)
+      : {};
+    const requestedMode: DiagnosticDispatchMode =
+      requestBody.mode === 'keyword' || requestBody.mode === 'both' ? requestBody.mode : 'targeted';
+    const explicitRepos = normalizeStringList(requestBody.repos);
+    const keywordTerms = normalizeStringList(requestBody.searchKeywords ?? requestBody.keywords);
+    const queueRepo = resolveResearchQueueRepo(c.env);
+    const callbackUrl = buildResearchCallbackUrl(c);
+    const ghToken = await getGithubToken(c.env);
 
-     logger.info('Triggering diagnostic dispatch test', { testId, repo, dispatcherUri });
+    if (!ghToken) {
+      throw new Error('Missing GitHub token for diagnostic research dispatch');
+    }
 
-     const dispatchPayload = {
-         event_type: 'research-dispatcher-start',
-         client_payload: {
-             task_id: testId,
-             github_keywords: 'test, diagnostics',
-             discord_keywords: 'test',
-             cloudflare_keywords: 'test',
-             discord_channels: '',
-             target_repos: repo,
-             timestamp: new Date().toISOString()
-         }
-     };
+    const baseId = cString(requestBody.projectId) || cString(requestBody.taskId) || `test-${Date.now()}`;
+    const dispatchPlans: ResearchWorkflowDispatchPlan[] = [];
 
-     const ghToken = await getGithubToken(c.env);
+    if (requestedMode === 'targeted' || requestedMode === 'both') {
+      dispatchPlans.push(
+        buildResearchDispatchPlan({
+          callbackUrl,
+          githubTerms:
+            explicitRepos.length > 0 ? explicitRepos : ['cloudflare/workers-sdk', 'cloudflare/agents'],
+          projectId: requestedMode === 'both' ? `${baseId}-targeted` : baseId,
+          taskId: requestedMode === 'both' ? `${baseId}-targeted` : baseId,
+        }),
+      );
+    }
 
-     const res = await fetch(dispatcherUri, {
-         method: 'POST',
-         headers: {
-             'Accept': 'application/vnd.github.v3+json',
-             'Authorization': `Bearer ${ghToken}`,
-             'User-Agent': 'core-github-api/1.0',
-             'Content-Type': 'application/json'
-         },
-         body: JSON.stringify(dispatchPayload)
-     });
+    if (requestedMode === 'keyword' || requestedMode === 'both') {
+      dispatchPlans.push(
+        buildResearchDispatchPlan({
+          callbackUrl,
+          goal: 'diagnostic research dispatch',
+          googleTerms:
+            keywordTerms.length > 0 ? keywordTerms : ['cloudflare workers', 'durable objects'],
+          projectId: requestedMode === 'both' ? `${baseId}-keywords` : baseId,
+          taskId: requestedMode === 'both' ? `${baseId}-keywords` : baseId,
+        }),
+      );
+    }
 
-     if (!res.ok) {
-         const t = await res.text();
-         throw new Error(`Diagnostic dispatch failed: ${res.status} ${t}`);
-     }
+    logger.info('Triggering diagnostic research dispatch', {
+      callbackUrl,
+      dispatcherUri: queueRepo.dispatcherUri,
+      mode: requestedMode,
+      repo: queueRepo.fullName,
+    });
 
-     const link = `https://github.com/${repo}/tree/main/daily-research/${testId}`;
-     
-     logger.info('Diagnostic dispatch initiated successfully', { testId, link });
-     await logger.flush();
-     
-     return c.json({ success: true, message: 'Diagnostic dispatch sent', testId, link });
-  } catch(error: any) {
-     logger.error('Diagnostic dispatch failed', { error: error.message, stack: error.stack });
-     await logger.flush();
-     return c.json({ error: error.message }, 500);
+    const dispatches: Array<{ link: string; mode: string; taskId: string }> = [];
+    for (const plan of dispatchPlans) {
+      await dispatchResearchWorkflow(queueRepo.dispatcherUri, plan.payload, ghToken);
+      const taskId = String(plan.payload.client_payload.task_id);
+      dispatches.push({
+        link: `https://github.com/${queueRepo.fullName}/tree/main/daily-research/${taskId}`,
+        mode: plan.mode,
+        taskId,
+      });
+    }
+
+    const diagnosticLink =
+      requestedMode === 'both'
+        ? `https://github.com/${queueRepo.fullName}/tree/main/daily-research`
+        : dispatches[0]?.link;
+
+    logger.info('Diagnostic dispatch initiated successfully', {
+      dispatchCount: dispatches.length,
+      link: diagnosticLink,
+      mode: requestedMode,
+    });
+    await logger.flush();
+
+    return c.json({
+      success: true,
+      message: 'Diagnostic dispatch sent',
+      mode: requestedMode,
+      dispatches,
+      testId: dispatches[0]?.taskId,
+      link: diagnosticLink,
+    });
+  } catch (error: any) {
+    logger.error('Diagnostic dispatch failed', { error: error.message, stack: error.stack });
+    await logger.flush();
+    return c.json({ error: error.message }, 500);
   }
 });
 

--- a/src/backend/src/routes/api/frontend/research/workflow-contract.ts
+++ b/src/backend/src/routes/api/frontend/research/workflow-contract.ts
@@ -1,0 +1,331 @@
+export type ResearchDispatchMode = 'research-targeted' | 'research-keywords';
+
+export type ResearchWorkflowEventType =
+  | 'health'
+  | 'research-targeted'
+  | 'research-keywords'
+  | 'research-dispatcher-start'
+  | 'research-health-check'
+  | 'research-task'
+  | 'research-keyword';
+
+type ResearchDispatchPayload = {
+  event_type: ResearchWorkflowEventType;
+  client_payload: Record<string, unknown>;
+};
+
+export type ResearchWorkflowDispatchPlan = {
+  mode: ResearchDispatchMode;
+  payload: ResearchDispatchPayload;
+  targetedRepos: string[];
+  keywordTerms: string[];
+};
+
+export type BuildResearchDispatchPlanInput = {
+  callbackUrl: string;
+  githubTerms?: string[] | null;
+  googleTerms?: string[] | null;
+  goal?: string | null;
+  projectId: string;
+  taskId?: string;
+  maxWorkerRepos?: number;
+};
+
+export type NormalizedResearchWorkflowCallback = {
+  event: ResearchWorkflowEventType;
+  mode: 'health' | ResearchDispatchMode;
+  orchestratorPath: string;
+  path: string;
+  projectId: string;
+  resultsFile?: string;
+  status: string;
+  taskId: string;
+  clonedRepos: number;
+  discoveredRepos: number;
+  newDiscoveredRepos: number;
+};
+
+const LEGACY_HEALTH_EVENTS = new Set<ResearchWorkflowEventType>(['health', 'research-health-check']);
+const LEGACY_KEYWORD_EVENTS = new Set<ResearchWorkflowEventType>(['research-keywords', 'research-keyword']);
+const LEGACY_TARGETED_EVENTS = new Set<ResearchWorkflowEventType>(['research-targeted', 'research-task']);
+const TARGETED_RESULTS_FILE = 'targeted-repo-research-results.json';
+const KEYWORD_RESULTS_FILE = 'cloudflare-worker-search-results.json';
+
+const GITHUB_REPO_PATTERN =
+  /^(?:https?:\/\/github\.com\/)?([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/i;
+
+function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (seen.has(trimmed)) {
+      continue;
+    }
+
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+export function normalizeGitHubRepoTarget(value: string): string | null {
+  const trimmed = value.trim();
+  const match = GITHUB_REPO_PATTERN.exec(trimmed);
+
+  if (!match) {
+    return null;
+  }
+
+  const owner = match[1];
+  const repo = match[2];
+
+  return trimmed.startsWith('http://') || trimmed.startsWith('https://')
+    ? `https://github.com/${owner}/${repo}`
+    : `${owner}/${repo}`;
+}
+
+export function splitResearchTargets(terms?: string[] | null): {
+  targetedRepos: string[];
+  keywordTerms: string[];
+} {
+  const targetedRepos: string[] = [];
+  const keywordTerms: string[] = [];
+
+  for (const rawTerm of terms ?? []) {
+    const trimmed = rawTerm?.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const repoTarget = normalizeGitHubRepoTarget(trimmed);
+    if (repoTarget) {
+      targetedRepos.push(repoTarget);
+      continue;
+    }
+
+    keywordTerms.push(trimmed);
+  }
+
+  return {
+    targetedRepos: uniqueNonEmpty(targetedRepos),
+    keywordTerms: uniqueNonEmpty(keywordTerms),
+  };
+}
+
+export function buildResearchDispatchPlan(
+  input: BuildResearchDispatchPlanInput,
+): ResearchWorkflowDispatchPlan {
+  const githubTargets = splitResearchTargets(input.githubTerms);
+  const cloudflareKeywords = uniqueNonEmpty(input.googleTerms ?? []);
+  const combinedKeywordTerms = uniqueNonEmpty([
+    ...githubTargets.keywordTerms,
+    ...cloudflareKeywords,
+    input.goal ?? undefined,
+  ]);
+  const taskId = input.taskId ?? input.projectId;
+
+  if (githubTargets.targetedRepos.length > 0) {
+    return {
+      mode: 'research-targeted',
+      targetedRepos: githubTargets.targetedRepos,
+      keywordTerms: [],
+      payload: {
+        event_type: 'research-targeted',
+        client_payload: {
+          task_id: taskId,
+          project_id: input.projectId,
+          callback_url: input.callbackUrl,
+          repos: githubTargets.targetedRepos,
+          target_repos: JSON.stringify(githubTargets.targetedRepos),
+        },
+      },
+    };
+  }
+
+  const clientPayload: Record<string, unknown> = {
+    task_id: taskId,
+    project_id: input.projectId,
+    callback_url: input.callbackUrl,
+  };
+
+  if (combinedKeywordTerms.length > 0) {
+    clientPayload.search_keywords = JSON.stringify(combinedKeywordTerms);
+    clientPayload.keywords = combinedKeywordTerms;
+  }
+
+  if (cloudflareKeywords.length > 0) {
+    clientPayload.cloudflare_keywords = cloudflareKeywords.join(', ');
+  }
+
+  if (githubTargets.keywordTerms.length > 0) {
+    clientPayload.github_keywords = githubTargets.keywordTerms.join(', ');
+  }
+
+  if (typeof input.maxWorkerRepos === 'number' && Number.isFinite(input.maxWorkerRepos)) {
+    clientPayload.max_worker_repos = Math.max(1, Math.min(Math.trunc(input.maxWorkerRepos), 50));
+  }
+
+  return {
+    mode: 'research-keywords',
+    targetedRepos: [],
+    keywordTerms: combinedKeywordTerms,
+    payload: {
+      event_type: 'research-keywords',
+      client_payload: clientPayload,
+    },
+  };
+}
+
+function parseCount(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
+function inferCallbackMode(
+  rawMode: unknown,
+  event: ResearchWorkflowEventType,
+  resultsFile?: string,
+): 'health' | ResearchDispatchMode {
+  if (rawMode === 'health' || rawMode === 'research-targeted' || rawMode === 'research-keywords') {
+    return rawMode;
+  }
+
+  if (LEGACY_HEALTH_EVENTS.has(event)) {
+    return 'health';
+  }
+
+  if (LEGACY_TARGETED_EVENTS.has(event)) {
+    return 'research-targeted';
+  }
+
+  if (LEGACY_KEYWORD_EVENTS.has(event)) {
+    return 'research-keywords';
+  }
+
+  if (resultsFile?.endsWith(TARGETED_RESULTS_FILE)) {
+    return 'research-targeted';
+  }
+
+  return 'research-keywords';
+}
+
+function inferCallbackEvent(rawEvent: unknown, mode: unknown): ResearchWorkflowEventType {
+  if (
+    rawEvent === 'health' ||
+    rawEvent === 'research-targeted' ||
+    rawEvent === 'research-keywords' ||
+    rawEvent === 'research-dispatcher-start' ||
+    rawEvent === 'research-health-check' ||
+    rawEvent === 'research-task' ||
+    rawEvent === 'research-keyword'
+  ) {
+    return rawEvent;
+  }
+
+  if (mode === 'health') {
+    return 'health';
+  }
+
+  if (mode === 'research-targeted') {
+    return 'research-targeted';
+  }
+
+  return 'research-keywords';
+}
+
+function inferResultsFile(raw: Record<string, unknown>, taskId: string): string | undefined {
+  if (typeof raw.results_file === 'string' && raw.results_file.trim()) {
+    return raw.results_file.trim();
+  }
+
+  if (typeof raw.resultsFile === 'string' && raw.resultsFile.trim()) {
+    return raw.resultsFile.trim();
+  }
+
+  if (typeof raw.path === 'string' && raw.path.trim().endsWith('.json')) {
+    return raw.path.trim();
+  }
+
+  if (typeof raw.mode === 'string') {
+    if (raw.mode === 'research-targeted') {
+      return `daily-research/${taskId}/${TARGETED_RESULTS_FILE}`;
+    }
+    if (raw.mode === 'research-keywords') {
+      return `daily-research/${taskId}/${KEYWORD_RESULTS_FILE}`;
+    }
+  }
+
+  return undefined;
+}
+
+export function normalizeResearchWorkflowCallback(
+  raw: Record<string, unknown>,
+  routeProjectId?: string,
+): NormalizedResearchWorkflowCallback {
+  const taskId = String(
+    raw.task_id ??
+      raw.taskId ??
+      raw.project_id ??
+      raw.projectId ??
+      routeProjectId ??
+      'unknown-task',
+  );
+  const projectId = String(raw.project_id ?? raw.projectId ?? routeProjectId ?? taskId);
+  const resultsFile = inferResultsFile(raw, taskId);
+  const event = inferCallbackEvent(raw.event ?? raw.event_type, raw.mode);
+  const mode = inferCallbackMode(raw.mode, event, resultsFile);
+  const path = String(raw.path ?? raw.task_path ?? resultsFile ?? `daily-research/${taskId}`);
+  const orchestratorPath =
+    resultsFile ??
+    (mode === 'research-targeted'
+      ? `daily-research/${taskId}/${TARGETED_RESULTS_FILE}`
+      : mode === 'research-keywords'
+        ? `daily-research/${taskId}/${KEYWORD_RESULTS_FILE}`
+        : path);
+
+  return {
+    event,
+    mode,
+    orchestratorPath,
+    path,
+    projectId,
+    resultsFile,
+    status: String(raw.status ?? 'ready'),
+    taskId,
+    clonedRepos: parseCount(raw.cloned_repos ?? raw.clonedRepos),
+    discoveredRepos: parseCount(raw.discovered_repos ?? raw.discoveredRepos),
+    newDiscoveredRepos: parseCount(raw.new_discovered_repos ?? raw.newDiscoveredRepos),
+  };
+}
+
+export function buildResearchOrchestrationPrompt(
+  queueRepoFullName: string,
+  callback: NormalizedResearchWorkflowCallback,
+): string {
+  return [
+    `Begin Jules orchestration for research project ${callback.projectId}.`,
+    `Workflow task: ${callback.taskId}.`,
+    `Queue repo: ${queueRepoFullName}.`,
+    `Workflow mode: ${callback.mode}.`,
+    `Use ${callback.orchestratorPath} as the primary results input.`,
+    `Workflow task path: ${callback.path}.`,
+    `Cloned repos: ${callback.clonedRepos}.`,
+    `Discovered repos: ${callback.discoveredRepos}.`,
+    `New discovered repos: ${callback.newDiscoveredRepos}.`,
+  ].join(' ');
+}

--- a/src/backend/src/routes/api/frontend/research/workflow-contract.ts
+++ b/src/backend/src/routes/api/frontend/research/workflow-contract.ts
@@ -54,12 +54,17 @@ const KEYWORD_RESULTS_FILE = 'cloudflare-worker-search-results.json';
 const GITHUB_REPO_PATTERN =
   /^(?:https?:\/\/github\.com\/)?([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/i;
 
-function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
+function uniqueNonEmpty(values: readonly unknown[] | null | undefined): string[] {
   const seen = new Set<string>();
   const normalized: string[] = [];
 
-  for (const value of values) {
-    const trimmed = value?.trim();
+  const safeValues = Array.isArray(values) ? values : [];
+  for (const value of safeValues) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+
+    const trimmed = value.trim();
     if (!trimmed) {
       continue;
     }
@@ -98,8 +103,13 @@ export function splitResearchTargets(terms?: string[] | null): {
   const targetedRepos: string[] = [];
   const keywordTerms: string[] = [];
 
-  for (const rawTerm of terms ?? []) {
-    const trimmed = rawTerm?.trim();
+  const safeTerms = Array.isArray(terms) ? terms : [];
+  for (const rawTerm of safeTerms) {
+    if (typeof rawTerm !== 'string') {
+      continue;
+    }
+
+    const trimmed = rawTerm.trim();
     if (!trimmed) {
       continue;
     }
@@ -274,22 +284,23 @@ function inferResultsFile(raw: Record<string, unknown>, taskId: string): string 
 }
 
 export function normalizeResearchWorkflowCallback(
-  raw: Record<string, unknown>,
+  raw: Record<string, unknown> | null | undefined,
   routeProjectId?: string,
 ): NormalizedResearchWorkflowCallback {
+  const safeRaw = raw && typeof raw === 'object' ? raw : {};
   const taskId = String(
-    raw.task_id ??
-      raw.taskId ??
-      raw.project_id ??
-      raw.projectId ??
+    safeRaw.task_id ??
+      safeRaw.taskId ??
+      safeRaw.project_id ??
+      safeRaw.projectId ??
       routeProjectId ??
       'unknown-task',
   );
-  const projectId = String(raw.project_id ?? raw.projectId ?? routeProjectId ?? taskId);
-  const resultsFile = inferResultsFile(raw, taskId);
-  const event = inferCallbackEvent(raw.event ?? raw.event_type, raw.mode);
-  const mode = inferCallbackMode(raw.mode, event, resultsFile);
-  const path = String(raw.path ?? raw.task_path ?? resultsFile ?? `daily-research/${taskId}`);
+  const projectId = String(safeRaw.project_id ?? safeRaw.projectId ?? routeProjectId ?? taskId);
+  const resultsFile = inferResultsFile(safeRaw, taskId);
+  const event = inferCallbackEvent(safeRaw.event ?? safeRaw.event_type, safeRaw.mode);
+  const mode = inferCallbackMode(safeRaw.mode, event, resultsFile);
+  const path = String(safeRaw.path ?? safeRaw.task_path ?? resultsFile ?? `daily-research/${taskId}`);
   const orchestratorPath =
     resultsFile ??
     (mode === 'research-targeted'
@@ -305,11 +316,11 @@ export function normalizeResearchWorkflowCallback(
     path,
     projectId,
     resultsFile,
-    status: String(raw.status ?? 'ready'),
+    status: String(safeRaw.status ?? 'ready'),
     taskId,
-    clonedRepos: parseCount(raw.cloned_repos ?? raw.clonedRepos),
-    discoveredRepos: parseCount(raw.discovered_repos ?? raw.discoveredRepos),
-    newDiscoveredRepos: parseCount(raw.new_discovered_repos ?? raw.newDiscoveredRepos),
+    clonedRepos: parseCount(safeRaw.cloned_repos ?? safeRaw.clonedRepos),
+    discoveredRepos: parseCount(safeRaw.discovered_repos ?? safeRaw.discoveredRepos),
+    newDiscoveredRepos: parseCount(safeRaw.new_discovered_repos ?? safeRaw.newDiscoveredRepos),
   };
 }
 

--- a/tests/unit/research-workflow-contract.test.ts
+++ b/tests/unit/research-workflow-contract.test.ts
@@ -4,7 +4,11 @@ import {
   buildResearchDispatchPlan,
   buildResearchOrchestrationPrompt,
   normalizeResearchWorkflowCallback,
+  splitResearchTargets,
 } from '@/routes/api/frontend/research/workflow-contract';
+import researchOneTimeApi, {
+  buildResearchCallbackUrl,
+} from '@/routes/api/frontend/research/one-time';
 
 describe('research workflow contract', () => {
   it('builds explicit targeted dispatch payloads for repo refs and urls', () => {
@@ -118,5 +122,66 @@ describe('research workflow contract', () => {
       'daily-research/legacy-task/targeted-repo-research-results.json',
     );
     expect(callback.clonedRepos).toBe(2);
+  });
+
+  it('ignores non-string keyword and repo targets at runtime', () => {
+    const targets = splitResearchTargets([
+      'cloudflare/workers-sdk',
+      42,
+      null,
+      'workers ai',
+      { repo: 'bad' },
+    ] as unknown as string[]);
+
+    expect(targets).toEqual({
+      targetedRepos: ['cloudflare/workers-sdk'],
+      keywordTerms: ['workers ai'],
+    });
+  });
+
+  it('handles null callback payloads without crashing', () => {
+    const callback = normalizeResearchWorkflowCallback(null, 'proj-null');
+
+    expect(callback).toEqual({
+      taskId: 'proj-null',
+      projectId: 'proj-null',
+      status: 'ready',
+      event: 'research-keywords',
+      mode: 'research-keywords',
+      path: 'daily-research/proj-null',
+      orchestratorPath: 'daily-research/proj-null/cloudflare-worker-search-results.json',
+      resultsFile: undefined,
+      clonedRepos: 0,
+      discoveredRepos: 0,
+      newDiscoveredRepos: 0,
+    });
+  });
+});
+
+describe('research one-time route robustness', () => {
+  it('builds a callback URL from relative request data safely', () => {
+    const callbackUrl = buildResearchCallbackUrl({
+      env: {} as Env,
+      req: {
+        url: '/api/research/test-dispatch',
+        header: (name: string) => (name.toLowerCase() === 'host' ? 'example.test' : undefined),
+      },
+    } as never);
+
+    expect(callbackUrl).toBe('http://example.test/api/research/callback');
+  });
+
+  it('returns 400 for invalid callback JSON', async () => {
+    const response = await researchOneTimeApi.request('/callback', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        host: 'example.test',
+      },
+      body: '{',
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid JSON payload' });
   });
 });

--- a/tests/unit/research-workflow-contract.test.ts
+++ b/tests/unit/research-workflow-contract.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildResearchDispatchPlan,
+  buildResearchOrchestrationPrompt,
+  normalizeResearchWorkflowCallback,
+} from '@/routes/api/frontend/research/workflow-contract';
+
+describe('research workflow contract', () => {
+  it('builds explicit targeted dispatch payloads for repo refs and urls', () => {
+    const plan = buildResearchDispatchPlan({
+      callbackUrl: 'https://core-github-api.example/api/research/callback',
+      githubTerms: ['cloudflare/workers-sdk', 'https://github.com/cloudflare/agents/'],
+      projectId: 'proj-123',
+    });
+
+    expect(plan.mode).toBe('research-targeted');
+    expect(plan.targetedRepos).toEqual([
+      'cloudflare/workers-sdk',
+      'https://github.com/cloudflare/agents',
+    ]);
+    expect(plan.payload).toEqual({
+      event_type: 'research-targeted',
+      client_payload: {
+        task_id: 'proj-123',
+        project_id: 'proj-123',
+        callback_url: 'https://core-github-api.example/api/research/callback',
+        repos: ['cloudflare/workers-sdk', 'https://github.com/cloudflare/agents'],
+        target_repos: JSON.stringify([
+          'cloudflare/workers-sdk',
+          'https://github.com/cloudflare/agents',
+        ]),
+      },
+    });
+  });
+
+  it('builds keyword dispatch payloads without targeted repo fields', () => {
+    const plan = buildResearchDispatchPlan({
+      callbackUrl: 'https://core-github-api.example/api/research/callback',
+      githubTerms: ['workers ai', 'durable objects'],
+      googleTerms: ['cloudflare workers'],
+      projectId: 'proj-456',
+    });
+
+    expect(plan.mode).toBe('research-keywords');
+    expect(plan.targetedRepos).toEqual([]);
+    expect(plan.keywordTerms).toEqual([
+      'workers ai',
+      'durable objects',
+      'cloudflare workers',
+    ]);
+    expect(plan.payload.event_type).toBe('research-keywords');
+    expect(plan.payload.client_payload).toEqual({
+      task_id: 'proj-456',
+      project_id: 'proj-456',
+      callback_url: 'https://core-github-api.example/api/research/callback',
+      search_keywords: JSON.stringify([
+        'workers ai',
+        'durable objects',
+        'cloudflare workers',
+      ]),
+      keywords: ['workers ai', 'durable objects', 'cloudflare workers'],
+      cloudflare_keywords: 'cloudflare workers',
+      github_keywords: 'workers ai, durable objects',
+    });
+    expect(plan.payload.client_payload).not.toHaveProperty('repos');
+    expect(plan.payload.client_payload).not.toHaveProperty('target_repos');
+  });
+
+  it('normalizes the new callback body and builds an orchestration prompt from results_file', () => {
+    const callback = normalizeResearchWorkflowCallback({
+      task_id: 'task-789',
+      project_id: 'proj-789',
+      status: 'ready',
+      path: 'daily-research/task-789',
+      event: 'research-keywords',
+      mode: 'research-keywords',
+      results_file: 'daily-research/task-789/cloudflare-worker-search-results.json',
+      cloned_repos: '3',
+      discovered_repos: '12',
+      new_discovered_repos: '5',
+    });
+
+    expect(callback).toEqual({
+      taskId: 'task-789',
+      projectId: 'proj-789',
+      status: 'ready',
+      event: 'research-keywords',
+      mode: 'research-keywords',
+      path: 'daily-research/task-789',
+      orchestratorPath: 'daily-research/task-789/cloudflare-worker-search-results.json',
+      resultsFile: 'daily-research/task-789/cloudflare-worker-search-results.json',
+      clonedRepos: 3,
+      discoveredRepos: 12,
+      newDiscoveredRepos: 5,
+    });
+
+    expect(buildResearchOrchestrationPrompt('jmbish04/core-github-research', callback)).toContain(
+      'Use daily-research/task-789/cloudflare-worker-search-results.json as the primary results input.',
+    );
+  });
+
+  it('preserves legacy dispatcher-start callbacks by inferring targeted mode from results files', () => {
+    const callback = normalizeResearchWorkflowCallback(
+      {
+        task_id: 'legacy-task',
+        status: 'ready',
+        event: 'research-dispatcher-start',
+        results_file: 'daily-research/legacy-task/targeted-repo-research-results.json',
+        cloned_repos: '2',
+      },
+      'proj-legacy',
+    );
+
+    expect(callback.projectId).toBe('proj-legacy');
+    expect(callback.mode).toBe('research-targeted');
+    expect(callback.orchestratorPath).toBe(
+      'daily-research/legacy-task/targeted-repo-research-results.json',
+    );
+    expect(callback.clonedRepos).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- switch one-time research dispatch to explicit `research-targeted` and `research-keywords` payloads with `callback_url`
- normalize workflow callbacks via a shared helper and support both `/api/research/callback` and the legacy per-project callback path
- update diagnostic dispatch coverage and add unit tests for targeted, keyword, and callback contract handling

## Validation
- `pnpm exec vitest --run tests/unit/research-workflow-contract.test.ts`
- `pnpm test` *(fails in pre-existing `tests/unit/planning-health.test.ts` due `cloudflare:` ESM loader import)*
- `pnpm run check` *(fails in pre-existing `src/backend/src/ai/agents/JulesOverseer.ts` parse errors)*
- `pnpm run dry-run` *(fails in the same pre-existing `JulesOverseer.ts` parse errors)*