### PR TITLE
feat: implement PR Manager Agent DO schema initialization and fixes

### DIFF
--- a/src/backend/src/ai/agents/JulesOverseer.ts
+++ b/src/backend/src/ai/agents/JulesOverseer.ts
@@ -183,7 +183,6 @@ export class JulesOverseer extends JulesOverseerDurableObject {
         if (payload.type === 'insight') {
           const db = getDb(this.env.DB);
           await db.insert(learningAiInsights).values({
-          await db.insert(learningAiInsights).values({
             id: crypto.randomUUID(),
             sessionId: payload.sessionId,
             patternType: payload.patternType || 'anti_pattern',
@@ -229,7 +228,6 @@ export class JulesOverseer extends JulesOverseerDurableObject {
 
       await julesService.sendMessage(sessionId, OVERRIDE_MESSAGE);
 
-      await db.insert(learningAiInsights).values({
       await db.insert(learningAiInsights).values({
         id: crypto.randomUUID(),
         sessionId,

--- a/src/backend/src/ai/agents/pr-manager/PrManagerAgent.ts
+++ b/src/backend/src/ai/agents/pr-manager/PrManagerAgent.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { migrateAgentDb } from '../../../db/schemas/agents/stateful';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 import { createAgent, routeToAgent } from '../honi';
@@ -47,7 +48,7 @@ export class PrManagerAgent extends runtime.Agent {
     }
     if (url.pathname === '/api/jobs') {
       await this.onStart();
-      const results = this.sql.prepare("SELECT * FROM pr_manager_jobs ORDER BY created_at DESC LIMIT 50").all();
+      const results = this.ctx.storage.sql.prepare("SELECT * FROM pr_manager_jobs ORDER BY created_at DESC LIMIT 50").all();
       return new Response(JSON.stringify(results), {
         headers: { 'Content-Type': 'application/json' }
       });
@@ -57,25 +58,17 @@ export class PrManagerAgent extends runtime.Agent {
 
   async onStart() {
     // DO SQLite state management init
-    this.sql.prepare(`
-      CREATE TABLE IF NOT EXISTS pr_manager_jobs (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        owner TEXT NOT NULL,
-        repo TEXT NOT NULL,
-        pull_number INTEGER NOT NULL,
-        status TEXT NOT NULL,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
-      )
-    `).run();
+    await this.ctx.blockConcurrencyWhile(async () => {
+      migrateAgentDb(this.ctx.storage);
+    });
   }
 
   async scheduled() {
     console.log('[PrManagerAgent] Running scheduled PR scan...');
     // Ensure agent state is initialized
     await this.onStart();
-    const owner = this.env.TEST_REPO_OWNER || 'cloudflare';
-    const repo = this.env.TEST_REPO_NAME || 'core-github-api';
+    const owner = (this.env as any).TEST_REPO_OWNER || 'cloudflare';
+    const repo = (this.env as any).TEST_REPO_NAME || 'core-github-api';
 
     await setupOpenAIAgentClient(this.env, "workers-ai");
 
@@ -191,24 +184,25 @@ Output a JSON object with:
               if (!allResolved) {
                 console.log(`[PrManagerAgent] Low confidence in resolving PR #${pr.number}. Adding comment.`);
                 await octokit.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: "I am unable to confidently resolve these conflicts automatically. Manual intervention is required." });
-                this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_commented', Date.now(), Date.now()).run();
+
+                this.ctx.storage.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_commented', Date.now(), Date.now()).run();
                 await execInSandbox('git merge --abort');
               } else {
                  console.log(`[PrManagerAgent] High confidence in resolving PR #${pr.number}. Pushing merge commit...`);
                  await execInSandbox('git add .');
                  await execInSandbox('git commit -m "Auto-resolved merge conflicts"');
                  await execInSandbox(`git push origin ${headRef}`);
-                 this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now()).run();
+                 this.ctx.storage.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now()).run();
               }
             } else {
                // Merge succeeded cleanly? Should not happen if mergeable_state === 'dirty', but handle just in case
                console.log(`[PrManagerAgent] Merge surprisingly succeeded without conflicts for PR #${pr.number}`);
                await execInSandbox(`git push origin ${headRef}`);
-               this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now()).run();
+               this.ctx.storage.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_resolved', Date.now(), Date.now()).run();
             }
           } catch (err) {
              console.error(`[PrManagerAgent] Failed to merge PR #${pr.number}:`, err);
-             this.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_failed', Date.now(), Date.now()).run();
+             this.ctx.storage.sql.prepare('INSERT INTO pr_manager_jobs (owner, repo, pull_number, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)').bind(owner, repo, pr.number, 'conflict_failed', Date.now(), Date.now()).run();
           } finally {
              // Let Sandbox terminate normally, no explicit cleanup needed here unless requested.
           }

--- a/src/backend/src/db/schemas/agents/pr-manager.ts
+++ b/src/backend/src/db/schemas/agents/pr-manager.ts
@@ -1,0 +1,14 @@
+import { sqliteTable, integer, text, index } from "drizzle-orm/sqlite-core";
+
+export const prManagerJobs = sqliteTable(
+  "pr_manager_jobs",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    owner: text("owner").notNull(),
+    repo: text("repo").notNull(),
+    pullNumber: integer("pull_number").notNull(),
+    status: text("status").notNull(),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  }
+);

--- a/src/backend/src/db/schemas/agents/stateful.ts
+++ b/src/backend/src/db/schemas/agents/stateful.ts
@@ -71,6 +71,16 @@ export function migrateAgentDb(storage: DurableObjectStorage): void {
       CONSTRAINT status_check CHECK(status IN ('pending','active','completed','failed'))
     );
     CREATE INDEX IF NOT EXISTS idx_agent_activities_op ON agent_activities (operation_id);
+
+    CREATE TABLE IF NOT EXISTS pr_manager_jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      owner TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      pull_number INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
   `);
 }
 

--- a/submit.txt
+++ b/submit.txt
@@ -1,0 +1,6 @@
+Implement PR Manager Agent database initialization and Drizzle schemas
+
+- Adds `pr_manager_jobs` Drizzle ORM schema to map SQLite definitions correctly.
+- Updates `migrateAgentDb()` in `stateful.ts` to idempotently deploy the `pr_manager_jobs` DDL table during Durable Object startup.
+- Updates `PrManagerAgent.ts` to execute schema initialization properly using `this.ctx.blockConcurrencyWhile` and leverages the correct `this.ctx.storage.sql.prepare().bind().run()` pattern exposed by Cloudflare Workers Durable Objects.
+- Resolves syntax duplicate insertion code bug in `JulesOverseer.ts`.


### PR DESCRIPTION
Implement PR Manager Agent database initialization and Drizzle schemas

- Adds `pr_manager_jobs` Drizzle ORM schema to map SQLite definitions correctly.
- Updates `migrateAgentDb()` in `stateful.ts` to idempotently deploy the `pr_manager_jobs` DDL table during Durable Object startup.
- Updates `PrManagerAgent.ts` to execute schema initialization properly using `this.ctx.blockConcurrencyWhile` and leverages the correct `this.ctx.storage.sql.prepare().bind().run()` pattern exposed by Cloudflare Workers Durable Objects.
- Resolves syntax duplicate insertion code bug in `JulesOverseer.ts`.

---
*PR created automatically by Jules for task [14776777009675051249](https://jules.google.com/task/14776777009675051249) started by @jmbish04*