### PR TITLE
feat(actions): decouple discovery from AI — Jules analysis, zero Workers AI bleed

### DIFF
--- a/.github/workflows/daily-trends.yml
+++ b/.github/workflows/daily-trends.yml
@@ -1,12 +1,21 @@
 name: Daily Trend Hunter
+
+# Discovery only — NO AI. Searches GitHub for new repos, writes the raw finds to
+# a dated folder under discoveries/, commits them, and posts the raw list to the
+# dashboard so it is populated immediately. Analysis is done separately by Jules
+# (see jules-analyze-discoveries.yml), which keeps Workers AI cost at zero here.
+
 on:
   schedule:
     - cron: "0 8 * * *" # Runs at 8:00 AM UTC daily
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   hunt:
-    name: Fetch Trends & Curate via AI
+    name: Fetch Trends (discovery only)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,14 +26,11 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install requests pygithub litellm pydantic
+        run: pip install requests pygithub
 
-      - name: Run Hunter & AI Curation Script
+      - name: Run discovery (no AI)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CF_GATEWAY_ID: ${{ secrets.CLOUDFLARE_GATEWAY_ID }}
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_AI_GATEWAY_TOKEN }} 
           WORKER_API_URL: ${{ secrets.WORKER_API_URL_BASE }}/upsert/daily-trends
           WORKER_API_KEY: ${{ secrets.WORKER_API_KEY }}
         run: |
@@ -32,56 +38,41 @@ jobs:
           import os
           import requests
           import json
-          from datetime import datetime, timedelta
+          from datetime import datetime, timedelta, timezone
           from github import Github
-          from pydantic import BaseModel
-          from litellm import completion
-
-          # --- 1. Define the Structured Output Schema ---
-          class CuratedRepo(BaseModel):
-              name: str
-              url: str
-              category: str
-              why_its_interesting: str
-              innovation_score: int
-
-          class DailyReport(BaseModel):
-              trend_summary: str
-              top_picks: list[CuratedRepo]
 
           def get_raw_trends(g):
-              # Get User's Existing Stars (to avoid duplicates)
-              # Note: PyGithub get_starred() can be slow if you have thousands of stars.
-              me = g.get_user("${{ github.repository_owner }}")
+              me = g.get_user(os.environ["GITHUB_REPOSITORY_OWNER"])
               starred_ids = set()
               print("Fetching user stars...")
               for repo in me.get_starred():
                   starred_ids.add(repo.id)
 
-              date_since = (datetime.now() - timedelta(days=30)).strftime('%Y-%m-%d')
+              date_since = (datetime.now(timezone.utc) - timedelta(days=30)).strftime('%Y-%m-%d')
               queries = [
                   f"language:typescript created:>{date_since} sort:stars",
                   f"language:python created:>{date_since} sort:stars",
                   f"topic:google-apps-script created:>{date_since}",
-                  f"topic:cloudflare-workers created:>{date_since}"
+                  f"topic:cloudflare-workers created:>{date_since}",
               ]
-              
               watched_orgs = ["cloudflare", "openai", "google-gemini", "langchain-ai"]
               raw_repos = []
 
               print("Scanning for trending repos...")
               for q in queries:
-                  repos = g.search_repositories(query=q)
                   count = 0
-                  for repo in repos:
-                      if count >= 10: break # Top 10 per category
-                      if repo.id in starred_ids: continue
-                      
+                  for repo in g.search_repositories(query=q):
+                      if count >= 10:
+                          break
+                      if repo.id in starred_ids:
+                          continue
                       raw_repos.append({
                           "name": repo.full_name,
                           "description": repo.description or "No description",
                           "url": repo.html_url,
-                          "category": q.split(" ")[0]
+                          "stars": repo.stargazers_count,
+                          "created_at": repo.created_at.isoformat() if repo.created_at else None,
+                          "category": q.split(" ")[0],
                       })
                       count += 1
 
@@ -90,70 +81,73 @@ jobs:
                   try:
                       org = g.get_organization(org_name)
                       for repo in org.get_repos(sort="created", direction="desc"):
-                          if (datetime.now() - repo.created_at).days > 30: break
+                          created = repo.created_at
+                          if created and created.tzinfo is None:
+                              created = created.replace(tzinfo=timezone.utc)
+                          if created and (datetime.now(timezone.utc) - created).days > 30:
+                              break
                           raw_repos.append({
                               "name": repo.full_name,
                               "description": repo.description or "No description",
                               "url": repo.html_url,
-                              "category": "org_watch"
+                              "stars": repo.stargazers_count,
+                              "created_at": created.isoformat() if created else None,
+                              "category": "org_watch",
                           })
                   except Exception as e:
                       print(f"Skipping {org_name}: {e}")
 
-              return raw_repos
-
-          def curate_with_ai(raw_repos):
-              print(f"Sending {len(raw_repos)} repos to Cloudflare AI Gateway for curation...")
-              
-              api_base = f"https://gateway.ai.cloudflare.com/v1/{os.environ['CF_ACCOUNT_ID']}/{os.environ['CF_GATEWAY_ID']}/workers-ai/v1"
-              
-              prompt = f"Review the following list of newly created repositories. Select the top 5 most innovative or interesting ones, and provide a brief summary of today's trends.\n\nData: {json.dumps(raw_repos)}"
-
-              response = completion(
-                  model="openai/@cf/openai/gpt-oss-120b",
-                  api_base=api_base,
-                  api_key=os.environ["CF_API_TOKEN"],
-                  messages=[
-                      {"role": "system", "content": "You are an expert developer curating daily tech trends. Return ONLY valid JSON matching the requested schema."},
-                      {"role": "user", "content": prompt}
-                  ],
-                  response_format=DailyReport,
-                  max_tokens=4096,
-                  extra_body={"reasoning": {"effort": "high"}}
-              )
-
-              return response.choices[0].message.content
+              # De-dup by full name.
+              seen, deduped = set(), []
+              for r in raw_repos:
+                  if r["name"] in seen:
+                      continue
+                  seen.add(r["name"])
+                  deduped.append(r)
+              return deduped
 
           def main():
               g = Github(os.environ["GITHUB_TOKEN"])
-              
-              # 1. Fetch raw data from GitHub
               raw_repos = get_raw_trends(g)
-              
-              # 2. Curate using Cloudflare Workers AI + LiteLLM
-              ai_curated_json_str = curate_with_ai(raw_repos)
-              
-              # 3. Post to Worker
+
+              # 1) Write the raw finds to a dated folder (the durable record).
+              date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+              out_dir = os.path.join("discoveries", date)
+              os.makedirs(out_dir, exist_ok=True)
+              payload = {"date": datetime.now(timezone.utc).isoformat(), "count": len(raw_repos), "repos": raw_repos}
+              with open(os.path.join(out_dir, "trends-raw.json"), "w") as f:
+                  json.dump(payload, f, indent=2)
+              print(f"Wrote {len(raw_repos)} repos to {out_dir}/trends-raw.json")
+
+              # 2) Populate the dashboard with the RAW discoveries right away.
               worker_url = os.environ.get("WORKER_API_URL")
-              if worker_url:
-                  print("Posting curated trends to Worker API...")
-                  
-                  # Parse string to dict to ensure valid JSON payload
-                  payload = json.loads(ai_curated_json_str)
-                  payload["date"] = datetime.now().isoformat()
-                  
-                  headers = {
-                      "Content-Type": "application/json",
-                      "X-API-Key": os.environ["WORKER_API_KEY"],
-                      "User-Agent": "github-actions/hunter"
-                  }
-                  
-                  resp = requests.post(worker_url, json=payload, headers=headers)
-                  resp.raise_for_status()
-                  print("Successfully uploaded to Worker.")
+              if worker_url and os.environ.get("WORKER_API_KEY"):
+                  try:
+                      resp = requests.post(
+                          worker_url,
+                          json={"date": payload["date"], "stage": "raw", "repos": raw_repos},
+                          headers={
+                              "Content-Type": "application/json",
+                              "X-API-Key": os.environ["WORKER_API_KEY"],
+                              "User-Agent": "github-actions/discovery",
+                          },
+                          timeout=30,
+                      )
+                      resp.raise_for_status()
+                      print("Posted raw discoveries to dashboard.")
+                  except Exception as e:
+                      print(f"Dashboard post failed (non-fatal): {e}")
 
           if __name__ == "__main__":
               main()
           EOF
 
           python hunter.py
+
+      - name: Commit dated discoveries
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(discovery): daily trend finds"
+          file_pattern: "discoveries/**"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/dashboard-sync-analysis.yml
+++ b/.github/workflows/dashboard-sync-analysis.yml
@@ -1,0 +1,37 @@
+name: Dashboard Sync — Analysis
+
+# Deterministic, NO AI. When Jules's analysis.json lands under discoveries/,
+# push it to the dashboard so the dashboard shows the curated analysis. Keeps the
+# dashboard populated without any Workers AI call.
+
+on:
+  push:
+    paths:
+      - "discoveries/**/analysis.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Post newest analysis to the dashboard
+        env:
+          WORKER_API_URL: ${{ secrets.WORKER_API_URL_BASE }}/upsert/daily-trends
+          WORKER_API_KEY: ${{ secrets.WORKER_API_KEY }}
+        run: |
+          set -euo pipefail
+          latest="$(ls -1d discoveries/*/analysis.json 2>/dev/null | sort | tail -1 || true)"
+          if [ -z "$latest" ]; then echo "no analysis.json found"; exit 0; fi
+          echo "Posting $latest to dashboard"
+          curl -sS -X POST "$WORKER_API_URL" \
+            -H "Content-Type: application/json" \
+            -H "X-API-Key: $WORKER_API_KEY" \
+            -H "User-Agent: github-actions/dashboard-sync" \
+            --data-binary "@$latest" \
+            --fail-with-body
+          echo "dashboard updated"

--- a/.github/workflows/jules-analyze-discoveries.yml
+++ b/.github/workflows/jules-analyze-discoveries.yml
@@ -1,0 +1,45 @@
+name: Jules — Analyze Discoveries
+
+# Analysis runs on Jules (Google infra), NOT Workers AI — so this adds zero
+# Workers AI cost. Jules reads the newest dated discovery finds, curates them,
+# and writes analysis.json (dashboard schema) + analysis.md back into the same
+# folder. The dashboard-sync-analysis workflow then pushes analysis.json to the
+# dashboard when it lands.
+
+on:
+  schedule:
+    - cron: "0 12 * * *" # Noon UTC — a few hours after discovery (08:00)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-labs-code/jules-invoke@v1
+        with:
+          prompt: |
+            You are the discovery analyst for this repository.
+
+            1. Find the NEWEST dated folder under `discoveries/` (format YYYY-MM-DD)
+               and read its `trends-raw.json` (a list of newly discovered GitHub repos).
+            2. Curate the finds: pick the top 5 most innovative/interesting repos and
+               write a short summary of today's trends.
+            3. Write TWO files INTO that same dated folder:
+               - `analysis.json` — EXACTLY this schema, nothing else:
+                 {
+                   "date": "<ISO timestamp>",
+                   "stage": "analyzed",
+                   "trend_summary": "<2-3 sentence summary>",
+                   "top_picks": [
+                     { "name": "owner/repo", "url": "...", "category": "...",
+                       "why_its_interesting": "...", "innovation_score": <1-10> }
+                   ]
+                 }
+               - `analysis.md` — a human-readable brief of the same content.
+            4. Open a pull request with both files.
+
+            Do not call any external paid AI API — use your own capabilities only.

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,7 +1,9 @@
 name: Sync Repos to D1 Cache
 on:
-  schedule:
-    - cron: "0 2 * * *" # Run daily at 2am
+  # Schedule disabled: this job looped over repos calling Workers AI (gpt-oss)
+  # daily. Analysis now runs on Jules (jules-analyze-discoveries.yml).
+  # schedule:
+  #   - cron: "0 2 * * *"
   workflow_dispatch: # Manual trigger
 
 jobs:


### PR DESCRIPTION
Mirror of core-github-standardization#4. Scheduled workflows looped repos through Workers AI (gpt-oss) constantly (~$32/day from GitHub runners). This decouples discovery from analysis:

- **daily-trends**: discovery only (no AI) → `discoveries/<date>/trends-raw.json` + commit + POST raw to dashboard.
- **jules-analyze-discoveries** (new): Jules (Google infra, not Workers AI) curates the dated finds → `analysis.json` + `analysis.md` → PR.
- **dashboard-sync-analysis** (new): on push of analysis.json, POST it to the dashboard (deterministic, no AI).
- **repo-sync**: schedule disabled (looped repos through gpt-oss); manual-only.

Discovery still flows daily, dashboard stays populated (raw + Jules analysis), and scheduled Workers AI cost → **zero**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)